### PR TITLE
feat: add tests to verify initial rendering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy -- -D warnings
       - run: cargo fmt -- --check
+      - run: cargo test --lib --tests

--- a/.mise.toml
+++ b/.mise.toml
@@ -22,5 +22,14 @@ done
 description = "Run tests"
 run = [
   "cargo clippy -- -D warnings",
-  "cargo fmt -- --check"
+  "cargo fmt -- --check",
+  "cargo test --lib --tests"
+]
+
+[tasks.coverage]
+description = "Run tests with coverage"
+run = [
+  "cargo clippy -- -D warnings",
+  "cargo fmt -- --check",
+  "cargo tarpaulin --lib --tests"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ keywords = ["cli", "prompt", "console"]
 console = "0.15.8"
 once_cell = "1.19.0"
 termcolor = "1.4.1"
+
+[dev-dependencies]
+ctor = "0.2.6"
+indoc = "2.0.4"

--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -2,6 +2,7 @@ use demand::Confirm;
 
 fn main() {
     let ms = Confirm::new("Are you sure?")
+        .description("This will do a thing.")
         .affirmative("Yes!")
         .negative("No.");
     let yes = ms.run().expect("error running confirm");

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -13,10 +13,10 @@ use crate::theme::Theme;
 /// ```rust
 /// use demand::Confirm;
 ///
-/// let ms = Confirm::new("Are you sure?")
+/// let confirm = Confirm::new("Are you sure?")
 ///   .affirmative("Yes!")
 ///   .negative("No.");
-/// let yes = ms.run().expect("error running confirm");
+/// let yes = confirm.run().expect("error running confirm");
 /// println!("yes: {}", yes);
 /// ```
 pub struct Confirm<'a> {
@@ -199,5 +199,32 @@ impl<'a> Confirm<'a> {
         self.term.clear_last_lines(self.height)?;
         self.height = 0;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::without_ansi;
+    use indoc::indoc;
+
+    #[test]
+    fn test_render() {
+        let confirm = Confirm::new("Are you sure?")
+            .description("This will do a thing.")
+            .affirmative("Yes!")
+            .negative("No.");
+
+        assert_eq!(
+            indoc! {
+              " Are you sure? This will do a thing.
+
+
+                 Yes!     No.  
+
+              ←/→ toggle • y/n/enter submit"
+            },
+            without_ansi(confirm.render().unwrap().as_str())
+        );
     }
 }

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -133,12 +133,11 @@ impl<'a> Confirm<'a> {
         let mut out = Buffer::ansi();
 
         out.set_color(&self.theme.title)?;
-        write!(out, " {}", self.title)?;
+        writeln!(out, " {}", self.title)?;
 
         if !self.description.is_empty() {
             out.set_color(&self.theme.description)?;
             write!(out, " {}", self.description)?;
-            writeln!(out)?;
         }
         writeln!(out, "\n")?;
 
@@ -217,8 +216,8 @@ mod tests {
 
         assert_eq!(
             indoc! {
-              " Are you sure? This will do a thing.
-
+              " Are you sure?
+               This will do a thing.
 
                  Yes!     No.  
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -18,7 +18,7 @@ use crate::{theme, Theme};
 ///   .description("We'll use this to personalize your experience.")
 ///   .placeholder("Enter your name");
 /// let name = input.run().expect("error running input");
-/// ````
+/// ```
 pub struct Input<'a> {
     /// The title of the input
     pub title: String,

--- a/src/input.rs
+++ b/src/input.rs
@@ -266,6 +266,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_render() {
+        let mut input = Input::new("Title")
+            .description("Description")
+            .prompt("$ ")
+            .placeholder("Placeholder");
+
+        assert_eq!(
+            " Title\n Description\n $ Placeholder",
+            without_ansi(input.render().unwrap().as_str())
+        );
+    }
+
+    #[test]
     fn test_render_title() {
         let mut input = Input::new("Title");
 
@@ -301,19 +314,6 @@ mod tests {
 
         assert_eq!(
             " Title\n > Placeholder",
-            without_ansi(input.render().unwrap().as_str())
-        );
-    }
-
-    #[test]
-    fn test_render_all() {
-        let mut input = Input::new("Title")
-            .description("Description")
-            .prompt("$ ")
-            .placeholder("Placeholder");
-
-        assert_eq!(
-            " Title\n Description\n $ Placeholder",
             without_ansi(input.render().unwrap().as_str())
         );
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -18,6 +18,7 @@ use crate::{theme, Theme};
 ///   .description("We'll use this to personalize your experience.")
 ///   .placeholder("Enter your name");
 /// let name = input.run().expect("error running input");
+/// ````
 pub struct Input<'a> {
     /// The title of the input
     pub title: String,
@@ -255,5 +256,65 @@ impl<'a> Input<'a> {
         self.term.clear_last_lines(self.height)?;
         self.height = 0;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::without_ansi;
+
+    use super::*;
+
+    #[test]
+    fn test_render_title() {
+        let mut input = Input::new("Title");
+
+        assert_eq!(
+            " Title\n > ",
+            without_ansi(input.render().unwrap().as_str())
+        );
+    }
+
+    #[test]
+    fn test_render_description() {
+        let mut input = Input::new("Title").description("Description");
+
+        assert_eq!(
+            " Title\n Description\n > ",
+            without_ansi(input.render().unwrap().as_str())
+        );
+    }
+
+    #[test]
+    fn test_render_prompt() {
+        let mut input = Input::new("Title").prompt("$ ");
+
+        assert_eq!(
+            " Title\n $ ",
+            without_ansi(input.render().unwrap().as_str())
+        );
+    }
+
+    #[test]
+    fn test_render_placeholder() {
+        let mut input = Input::new("Title").placeholder("Placeholder");
+
+        assert_eq!(
+            " Title\n > Placeholder",
+            without_ansi(input.render().unwrap().as_str())
+        );
+    }
+
+    #[test]
+    fn test_render_all() {
+        let mut input = Input::new("Title")
+            .description("Description")
+            .prompt("$ ")
+            .placeholder("Placeholder");
+
+        assert_eq!(
+            " Title\n Description\n $ Placeholder",
+            without_ansi(input.render().unwrap().as_str())
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,6 @@ mod option;
 mod select;
 mod spinner;
 mod theme;
+
+#[cfg(test)]
+mod test;

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -15,7 +15,7 @@ use crate::{theme, DemandOption};
 /// ```rust
 /// use demand::{DemandOption, MultiSelect};
 ///
-/// let ms = MultiSelect::new("Toppings")
+/// let multiselect = MultiSelect::new("Toppings")
 ///   .description("Select your toppings")
 ///   .min(1)
 ///   .max(4)
@@ -26,8 +26,8 @@ use crate::{theme, DemandOption};
 ///   .option(DemandOption::new("Jalapenos").label("Jalapeños"))
 ///   .option(DemandOption::new("Cheese"))
 ///   .option(DemandOption::new("Vegan Cheese"))
-///   .option(DemandOption::new("Nutella"));///
-/// let toppings = ms.run().expect("error running multi select");
+///   .option(DemandOption::new("Nutella"));
+/// let toppings = multiselect.run().expect("error running multi select");
 /// ```
 pub struct MultiSelect<'a, T: Display> {
     /// The title of the selector
@@ -420,5 +420,36 @@ impl<'a, T: Display> MultiSelect<'a, T> {
         self.term.clear_last_lines(self.height)?;
         self.height = 0;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::without_ansi;
+
+    use super::*;
+    use indoc::indoc;
+
+    #[test]
+    fn test_render() {
+        let select = MultiSelect::new("Toppings")
+            .description("Select your toppings")
+            .option(DemandOption::new("Lettuce").selected(true))
+            .option(DemandOption::new("Tomatoes").selected(true))
+            .option(DemandOption::new("Charm Sauce"))
+            .option(DemandOption::new("Jalapenos").label("Jalapeños"))
+            .option(DemandOption::new("Cheese"))
+            .option(DemandOption::new("Vegan Cheese"))
+            .option(DemandOption::new("Nutella"));
+
+        assert_eq!(
+            indoc! {
+              " Toppings
+             Select your toppings
+           
+            ↑/↓/k/j up/down • x/space toggle • a toggle all • enter confirm"
+            },
+            without_ansi(select.render().unwrap().as_str())
+        );
     }
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -14,7 +14,7 @@ use crate::{theme, DemandOption};
 /// ```rust
 /// use demand::{DemandOption, Select};
 ///
-/// let ms = Select::new("Toppings")
+/// let select = Select::new("Toppings")
 ///   .description("Select your topping")
 ///   .filterable(true)
 ///   .option(DemandOption::new("Lettuce"))
@@ -24,7 +24,7 @@ use crate::{theme, DemandOption};
 ///   .option(DemandOption::new("Cheese"))
 ///   .option(DemandOption::new("Vegan Cheese"))
 ///   .option(DemandOption::new("Nutella"));
-/// let topping = ms.run().expect("error running multi select");
+/// let topping = select.run().expect("error running multi select");
 /// ```
 pub struct Select<'a, T: Display> {
     /// The title of the selector
@@ -314,5 +314,34 @@ impl<'a, T: Display> Select<'a, T> {
         self.term.clear_last_lines(self.height)?;
         self.height = 0;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::without_ansi;
+
+    use super::*;
+    use indoc::indoc;
+
+    #[test]
+    fn test_render() {
+        let select = Select::new("Country")
+            .description("Select your Country")
+            .option(DemandOption::new("United States").selected(true))
+            .option(DemandOption::new("Germany"))
+            .option(DemandOption::new("Brazil"))
+            .option(DemandOption::new("Canada"))
+            .option(DemandOption::new("Mexico"));
+
+        assert_eq!(
+            indoc! {
+              " Country
+               Select your Country
+             
+              ↑/↓/k/j up/down • enter confirm"
+            },
+            without_ansi(select.render().unwrap().as_str())
+        );
     }
 }

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -178,3 +178,31 @@ impl SpinnerStyle {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::test::without_ansi;
+
+    use super::*;
+
+    #[test]
+    fn test_render() {
+        for t in vec![
+            SpinnerStyle::dots(),
+            SpinnerStyle::jump(),
+            SpinnerStyle::line(),
+            SpinnerStyle::points(),
+            SpinnerStyle::meter(),
+            SpinnerStyle::minidots(),
+            SpinnerStyle::ellipsis(),
+        ] {
+            let mut spinner = Spinner::new("Loading data...").style(t);
+            for f in spinner.style.chars.clone().iter() {
+                assert_eq!(
+                    format!("{} Loading data...", f),
+                    without_ansi(spinner.render().unwrap().as_str())
+                );
+            }
+        }
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,11 @@
+use std::borrow::Cow;
+
+#[ctor::ctor]
+fn init() {
+    console::set_colors_enabled(false);
+    console::set_colors_enabled_stderr(false);
+}
+
+pub fn without_ansi(s: &str) -> Cow<str> {
+    console::strip_ansi_codes(s)
+}


### PR DESCRIPTION
@jdx Not sure how useful these could be as they only check the initial rendering but they already show 2 issues.
* confirm - description is on same line as title (intended?)
* select/multiselect - do not render options since initialization (capacity/pages) happens in run