### PR TITLE
🚧 fix: inputs get messed up when a line overflows

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,19 @@
+use console::Term;
+
+/// Returns a tuple with the height of the output and the number of lines that overflow the terminal width
+pub fn get_height(term: &Term, output: String) -> (usize, usize) {
+    let max_width = term.size().1 as usize;
+    let height = output.lines().count() - 1;
+    // calculate potential overflow of lines overflowing terminal width
+    let overflow = output
+        .lines()
+        .map(|l| {
+            if l.chars().count() > max_width {
+                l.chars().count() / max_width
+            } else {
+                0
+            }
+        })
+        .sum::<usize>();
+    (height, overflow)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub use spinner::Spinner;
 pub use spinner::SpinnerStyle;
 pub use theme::Theme;
 
+mod common;
 mod confirm;
 mod input;
 mod multiselect;

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -8,7 +8,7 @@ use console::Term;
 use once_cell::sync::Lazy;
 use termcolor::{Buffer, WriteColor};
 
-use crate::{theme, Theme};
+use crate::{common, theme, Theme};
 
 /// Show a spinner
 ///
@@ -36,6 +36,7 @@ pub struct Spinner<'a> {
     term: Term,
     frame: usize,
     height: usize,
+    overflow: usize,
 }
 
 impl<'a> Spinner<'a> {
@@ -48,6 +49,7 @@ impl<'a> Spinner<'a> {
             term: Term::stderr(),
             frame: 0,
             height: 0,
+            overflow: 0,
         }
     }
 
@@ -76,7 +78,6 @@ impl<'a> Spinner<'a> {
         loop {
             self.clear()?;
             let output = self.render()?;
-            self.height = output.lines().count() - 1;
             self.term.write_all(output.as_bytes())?;
             sleep(self.style.fps);
             if handle.is_finished() {
@@ -84,6 +85,7 @@ impl<'a> Spinner<'a> {
                 self.term.show_cursor()?;
                 break;
             }
+            self.update_height(output)?;
         }
         Ok(())
     }
@@ -107,7 +109,15 @@ impl<'a> Spinner<'a> {
         Ok(std::str::from_utf8(out.as_slice()).unwrap().to_string())
     }
 
+    fn update_height(&mut self, output: String) -> io::Result<()> {
+        let (height, overflow) = common::get_height(&self.term, output);
+        self.height = height;
+        self.overflow = overflow;
+        Ok(())
+    }
+
     fn clear(&mut self) -> io::Result<()> {
+        self.term.move_cursor_up(self.overflow)?;
         self.term.clear_to_end_of_screen()?;
         self.term.clear_last_lines(self.height)?;
         self.height = 0;


### PR DESCRIPTION
overflowing lines need to be calculated seperately of height so we can move the cursor accordingly before clearing. for `selects` this is much more involved since capacity of options also need to be calculated based on title,description and help which all might be overflowing.