### PR TITLE
scoped threads and less restrictive trait bounds

### DIFF
--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -29,7 +29,7 @@ use crate::{theme, DemandOption};
 ///   .option(DemandOption::new("Nutella"));
 /// let toppings = multiselect.run().expect("error running multi select");
 /// ```
-pub struct MultiSelect<'a, T: Display> {
+pub struct MultiSelect<'a, T> {
     /// The title of the selector
     pub title: String,
     /// The colors/style of the selector
@@ -55,7 +55,7 @@ pub struct MultiSelect<'a, T: Display> {
     capacity: usize,
 }
 
-impl<'a, T: Display> MultiSelect<'a, T> {
+impl<'a, T> MultiSelect<'a, T> {
     /// Create a new multi select with the given title
     pub fn new<S: Into<String>>(title: S) -> Self {
         let mut ms = MultiSelect {
@@ -468,6 +468,55 @@ mod tests {
               [ ] Cheese
               [ ] Vegan Cheese
               [ ] Nutella
+
+            ↑/↓/k/j up/down • x/space toggle • a toggle all • enter confirm"
+            },
+            without_ansi(select.render().unwrap().as_str())
+        );
+    }
+
+    #[test]
+    fn non_display() {
+        struct Thing {
+            num: u32,
+            thing: Option<()>,
+        }
+        let things = [
+            Thing {
+                num: 1,
+                thing: Some(()),
+            },
+            Thing {
+                num: 2,
+                thing: None,
+            },
+            Thing {
+                num: 3,
+                thing: None,
+            },
+        ];
+        let select = MultiSelect::new("things")
+            .description("pick a thing")
+            .options(
+                things
+                    .iter()
+                    .enumerate()
+                    .map(|(i, t)| {
+                        if i == 0 {
+                            DemandOption::with_label("First", t)
+                        } else {
+                            DemandOption::new(t.num).item(t).selected(true)
+                        }
+                    })
+                    .collect(),
+            );
+        assert_eq!(
+            indoc! {
+              " things
+             pick a thing
+             >[ ] First
+              [•] 2
+              [•] 3
 
             ↑/↓/k/j up/down • x/space toggle • a toggle all • enter confirm"
             },

--- a/src/option.rs
+++ b/src/option.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::AtomicUsize;
 
 /// An individual option in a select or multi-select.
 #[derive(Debug, Clone)]
-pub struct DemandOption<T: Display> {
+pub struct DemandOption<T> {
     /// Unique ID for this option.
     pub(crate) id: usize,
     /// The item this option represents.
@@ -14,8 +14,8 @@ pub struct DemandOption<T: Display> {
     pub selected: bool,
 }
 
-impl<T: Display> DemandOption<T> {
-    /// Create a new option with the given key.
+impl<T: ToString> DemandOption<T> {
+    /// Create a new option with the item as the label
     pub fn new(item: T) -> Self {
         static ID: AtomicUsize = AtomicUsize::new(0);
         Self {
@@ -25,7 +25,27 @@ impl<T: Display> DemandOption<T> {
             selected: false,
         }
     }
+}
 
+impl<T> DemandOption<T> {
+    /// Create a new option with a label and item
+    pub fn with_label<S: Into<String>>(label: S, item: T) -> Self {
+        static ID: AtomicUsize = AtomicUsize::new(0);
+        Self {
+            id: ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            label: label.into(),
+            item,
+            selected: false,
+        }
+    }
+    pub fn item<I>(self, item: I) -> DemandOption<I> {
+        DemandOption {
+            id: self.id,
+            item,
+            label: self.label,
+            selected: self.selected,
+        }
+    }
     /// Set the display label for this option.
     pub fn label(mut self, name: &str) -> Self {
         self.label = name.to_string();


### PR DESCRIPTION
I found `Spinner.run` and `DemandOption` to be overly restrictive in functionality that made it rather annoying to use
### Restrictive trait bounds
firstly, `DemandOption` requiring `item` to be display is rather ridiculous, after all it's the label that gets displayed even if the label is taken from the item.

So the item doesn't require display now, the `new fn` does the same thing it did before (making the label from the item) but it requires `ToString` instead because while before it required Display you were actually using `ToString` which you could do since `ToString` is impl on all `impl Display`. Requiring `ToString` is more accurate and allows types that impl `ToString` but not `Display`

Since `new` still requires item to be `ToString` we need another fn that allows us to take advantage of item not needing `Display` anymore. That's what `DemandOption::with_label` does, it takes a separate label and item, the label being `Into<String>` and item being just `T`. There is also `.item` fn to be consistent with the rest of the lib.

`Select` and  `MultiSelect` do not require `Display` either. For some reason, `Select` was using `item.to_string` instead of the label to render, which is the only place `ToString` and by extension `Display` was ever needed for `item`.

### Scoped threads
the old `Spinner.run` required a static Fn which means the Fn can only move or take static references which is really annoying especially since It's clearly not necessary since run will not return unless the thread is done. Thankfully, rust has scoped threads which remove this limitation. As a bonus I changed `run` to take a `FnOnce` which is more appropriate as it's only run once, and it allows for more closure magic, as well as have `run` return the value the `FnOnce` returns. If the thread running the `FnOnce` panics `run` will return an `io::Error` with the kind being `Other` (which exists precisely for when you need to return any error as an `io::Error`) with the value being the panic message.

*Just to be clear. None of the changes in this pr affect any code already using demand. You can just do more now*