### PR TITLE
run actions

### DIFF
--- a/examples/spinner-prompts.rs
+++ b/examples/spinner-prompts.rs
@@ -3,7 +3,7 @@ use demand::{Confirm, DemandOption, Input, MultiSelect, Select, Spinner, Theme};
 fn main() {
     let spinner = Spinner::new("im out here");
     spinner
-        .run(|| {
+        .run(|_| {
             Confirm::new("confirm")
                 .description("it says confirm")
                 .run()

--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -1,6 +1,6 @@
 use std::{thread::sleep, time::Duration};
 
-use demand::{Spinner, SpinnerAction, SpinnerStyle, Theme};
+use demand::{Spinner, SpinnerStyle, Theme};
 
 fn main() {
     let custom_style = SpinnerStyle {
@@ -9,27 +9,20 @@ fn main() {
         ],
         fps: Duration::from_millis(1000 / 10),
     };
+    let dots = SpinnerStyle::dots();
+    let line = SpinnerStyle::line();
 
+    let charm = Theme::charm();
+    let catppuccin = Theme::catppuccin();
     Spinner::new("Loading Data...")
-        .style(custom_style)
+        .style(&custom_style)
         .run(|s| {
             sleep(Duration::from_secs(2));
             let mut toggle = false;
             for name in ["Files", "Data", "Your Soul"] {
-                let _ = s.send(SpinnerAction::Title(format!("Loading {name}...")));
-                let _ = s.send(SpinnerAction::Style(if toggle {
-                    SpinnerStyle::dots()
-                } else {
-                    SpinnerStyle::line()
-                }));
-                let _ = s.send(SpinnerAction::Theme(
-                    if toggle {
-                        Theme::catppuccin()
-                    } else {
-                        Theme::charm()
-                    }
-                    .into(),
-                ));
+                let _ = s.title(format!("Loading {name}..."));
+                let _ = s.style(if toggle { &dots } else { &line });
+                let _ = s.theme(if toggle { &catppuccin } else { &charm });
                 toggle = !toggle;
                 sleep(Duration::from_secs(2));
             }

--- a/examples/spinner.rs
+++ b/examples/spinner.rs
@@ -1,6 +1,6 @@
 use std::{thread::sleep, time::Duration};
 
-use demand::{Spinner, SpinnerStyle};
+use demand::{Spinner, SpinnerAction, SpinnerStyle, Theme};
 
 fn main() {
     let custom_style = SpinnerStyle {
@@ -11,9 +11,28 @@ fn main() {
     };
 
     Spinner::new("Loading Data...")
-        .style(&custom_style)
-        .run(|| {
+        .style(custom_style)
+        .run(|s| {
             sleep(Duration::from_secs(2));
+            let mut toggle = false;
+            for name in ["Files", "Data", "Your Soul"] {
+                let _ = s.send(SpinnerAction::Title(format!("Loading {name}...")));
+                let _ = s.send(SpinnerAction::Style(if toggle {
+                    SpinnerStyle::dots()
+                } else {
+                    SpinnerStyle::line()
+                }));
+                let _ = s.send(SpinnerAction::Theme(
+                    if toggle {
+                        Theme::catppuccin()
+                    } else {
+                        Theme::charm()
+                    }
+                    .into(),
+                ));
+                toggle = !toggle;
+                sleep(Duration::from_secs(2));
+            }
         })
         .expect("error running spinner");
     println!("Data loaded.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub use multiselect::MultiSelect;
 pub use option::DemandOption;
 pub use select::Select;
 pub use spinner::Spinner;
+pub use spinner::SpinnerAction;
 pub use spinner::SpinnerStyle;
 pub use theme::Theme;
 


### PR DESCRIPTION
Spinner can do tricks now.

You can change the theme, style and name through a mpsc channel.

Had to make spinner own the Style and Theme to make this work, *granted i didn't put any effort into this*

The question at hand is what to do about themes, currently I just put it in a box to get this working, but that's not a good solution.
We could:
- not allow changing themes,
- require a static reference,
- do some unsafe magic, should be safe as long as spinner doesn't access it after the other thread ends.
- Rc or Arc, but that still has the same problem as box

I don't think owning the Style is nearly as much of a problem but should prob do the same with that as with Theme