### PR TITLE
small quick things

### DIFF
--- a/examples/input.rs
+++ b/examples/input.rs
@@ -15,7 +15,7 @@ fn main() {
         .description("We'll use this to personalize your experience.")
         .placeholder("Enter your name")
         .prompt("Name: ")
-        .suggestions(vec![
+        .suggestions(&[
             "Adam Grant",
             "Danielle Steel",
             "Eveline Widmer-Schlumpf",

--- a/examples/spinner-prompts.rs
+++ b/examples/spinner-prompts.rs
@@ -10,7 +10,7 @@ fn main() {
                 .unwrap();
             Input::new("input ")
                 .description("go on say something")
-                .suggestions(vec!["hello there"])
+                .suggestions(&["hello there"])
                 .validation(|s| match !s.contains('j') {
                     true => Ok(()),
                     false => Err("ew stinky 'j' not welcome here"),

--- a/src/input.rs
+++ b/src/input.rs
@@ -111,7 +111,7 @@ impl<'a> Input<'a> {
     }
 
     /// Sets the suggestions of the input
-    pub fn suggestions(mut self, suggestions: &'a [&'static str]) -> Self {
+    pub fn suggestions(mut self, suggestions: &'a [&'a str]) -> Self {
         self.suggestions = Some(suggestions);
         self
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -29,7 +29,7 @@ pub struct Input<'a> {
     /// A placeholder to display in the input
     pub placeholder: String,
     /// A list of suggestions to autocomplete from
-    pub suggestions: Vec<&'a str>,
+    pub suggestions: Option<&'a [&'a str]>,
     /// Show the input inline
     pub inline: bool,
     /// Whether to mask the input
@@ -62,7 +62,7 @@ impl<'a> Input<'a> {
             description: String::new(),
             prompt: "> ".to_string(),
             placeholder: String::new(),
-            suggestions: vec![],
+            suggestions: None,
             input: String::new(),
             inline: false,
             password: false,
@@ -111,8 +111,8 @@ impl<'a> Input<'a> {
     }
 
     /// Sets the suggestions of the input
-    pub fn suggestions(mut self, suggestions: Vec<&'static str>) -> Self {
-        self.suggestions = suggestions;
+    pub fn suggestions(mut self, suggestions: &'a [&'static str]) -> Self {
+        self.suggestions = Some(suggestions);
         self
     }
 
@@ -394,19 +394,15 @@ impl<'a> Input<'a> {
             self.suggestion = None;
             return Ok(());
         }
-        self.suggestion = self
-            .suggestions
-            .clone()
-            .into_iter()
-            .find(|s| s.to_lowercase().starts_with(&self.input.to_lowercase()))
-            .and_then(|s| {
-                let suggestion = s[self.input.len()..].to_string();
-                if !suggestion.is_empty() {
-                    Some(suggestion)
-                } else {
-                    None
-                }
-            });
+        if let Some(suggestions) = &self.suggestions {
+            self.suggestion = suggestions
+                .iter()
+                .find(|s| s.to_lowercase().starts_with(&self.input.to_lowercase()))
+                .and_then(|s| {
+                    let suggestion = s[self.input.len()..].to_string();
+                    (!suggestion.is_empty()).then_some(suggestion)
+                });
+        }
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ pub use multiselect::MultiSelect;
 pub use option::DemandOption;
 pub use select::Select;
 pub use spinner::Spinner;
-pub use spinner::SpinnerAction;
 pub use spinner::SpinnerStyle;
 pub use theme::Theme;
 

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -51,7 +51,7 @@ impl<'spinner> SpinnerActionRunner<'spinner> {
     /// set the spinner style
     /// will not compile if ref to style doesn't outlast spinner
     pub fn style(
-        &mut self, // with just this the compiler assumes that theme might be stored in self so it wont let u mutate it after this fn call
+        &mut self, // with just this the compiler assumes that style might be stored in self so it wont let u mutate it after this fn call
         style: &'spinner SpinnerStyle,
     ) -> Result<(), std::sync::mpsc::SendError<SpinnerAction>> {
         let style = unsafe { std::mem::transmute(style) };


### PR DESCRIPTION
`Input.suggestions()` takes a slice with non-static str's, it's more flexible.
Fixed a typo
removed a re-export I forgot to remove in #49 