### PR TITLE
feat: quit interactive menus with single-key shortcut escape

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,7 @@
 [tools]
-"cargo:cargo-tarpaulin" = "0.27.3"
-"cargo:git-cliff" = "1.4.0"
-"cargo:cargo-release" = "0.25.4"
+"cargo:cargo-tarpaulin" = "0.27"
+"cargo:git-cliff" = "1.4"
+"cargo:cargo-release" = "0.25"
 
 [tasks.changelog]
 description = "Generate changelog"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ readme = "README.md"
 keywords = ["cli", "prompt", "console"]
 
 [dependencies]
-console = "0.15.8"
-once_cell = "1.19.0"
-termcolor = "1.1"
+console = "0.15"
+once_cell = "1.20"
+termcolor = "1"
 
 [dev-dependencies]
-ctor = "0.2.8"
-indoc = "2.0.5"
+ctor = "0.2"
+indoc = "2"
 
 [package.metadata.release]
 allow-branch = ["main"]

--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -1,9 +1,19 @@
 use demand::Confirm;
 
 fn main() {
-    let ms = Confirm::new("Are you sure?")
+    let confirm = Confirm::new("Are you sure?")
         .description("This will do a thing.")
         .affirmative("Yes!")
         .negative("No.");
-    ms.run().expect("error running confirm");
+    let _ = match confirm.run() {
+        Ok(confirm) => confirm,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                println!("Dialog was cancelled");
+                false
+            } else {
+                panic!("Error: {}", e);
+            }
+        }
+    };
 }

--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -1,7 +1,7 @@
 use demand::{Dialog, DialogButton};
 
 fn main() {
-    let ms = Dialog::new("Are you sure?")
+    let dialog = Dialog::new("Are you sure?")
         .description("This will do a thing.")
         .buttons(vec![
             DialogButton::new("Ok"),
@@ -9,5 +9,15 @@ fn main() {
             DialogButton::new("Cancel"),
         ])
         .selected_button(1);
-    ms.run().expect("error running confirm");
+    let _ = match dialog.run() {
+        Ok(value) => value,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                println!("Dialog was cancelled");
+                return;
+            } else {
+                panic!("Error: {}", e);
+            }
+        }
+    };
 }

--- a/examples/input-password.rs
+++ b/examples/input-password.rs
@@ -1,9 +1,19 @@
 use demand::Input;
 
 fn main() {
-    let t = Input::new("Set a password")
+    let input = Input::new("Set a password")
         .placeholder("Enter password")
         .prompt("Password: ")
         .password(true);
-    t.run().expect("error running input");
+    let _ = match input.run() {
+        Ok(value) => value,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                println!("Input cancelled");
+                return;
+            } else {
+                panic!("Error: {}", e);
+            }
+        }
+    };
 }

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -11,7 +11,7 @@ fn main() {
         Ok(())
     };
 
-    let t = Input::new("What's your name?")
+    let input = Input::new("What's your name?")
         .description("We'll use this to personalize your experience.")
         .placeholder("Enter your name")
         .prompt("Name: ")
@@ -26,5 +26,15 @@ fn main() {
             "Zack Snyder",
         ])
         .validation(notempty_minlen);
-    t.run().expect("error running input");
+    let _ = match input.run() {
+        Ok(value) => value,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                println!("Input cancelled");
+                return;
+            } else {
+                panic!("Error: {}", e);
+            }
+        }
+    };
 }

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -1,7 +1,9 @@
+use std::io;
+
 use demand::List;
 
 fn main() {
-    let _ = List::new("Toppings")
+    let list = List::new("Toppings")
         .description("List of available toppings")
         .item("Lettuce")
         .item("Tomatoes")
@@ -64,6 +66,16 @@ fn main() {
         .item("Starburst")
         .item("Twizzlers")
         .item("Milk Duds")
-        .filterable(true)
-        .run();
+        .filterable(true);
+    let _ = match list.run() {
+        Ok(_) => {}
+        Err(e) => {
+            if e.kind() == io::ErrorKind::Interrupted {
+                println!("Input cancelled");
+                return;
+            } else {
+                panic!("Error: {}", e);
+            }
+        }
+    };
 }

--- a/examples/multiselect.rs
+++ b/examples/multiselect.rs
@@ -1,7 +1,7 @@
 use demand::{DemandOption, MultiSelect};
 
 fn main() {
-    let ms = MultiSelect::new("Toppings")
+    let multiselect = MultiSelect::new("Toppings")
         .description("Select your toppings")
         .min(1)
         .max(4)
@@ -13,5 +13,15 @@ fn main() {
         .option(DemandOption::new("Cheese"))
         .option(DemandOption::new("Vegan Cheese"))
         .option(DemandOption::new("Nutella"));
-    ms.run().expect("error running multi select");
+    let _ = match multiselect.run() {
+        Ok(toppings) => toppings,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                println!("Input cancelled");
+                return;
+            } else {
+                panic!("Error: {}", e);
+            }
+        }
+    };
 }

--- a/examples/multiselect_huge.rs
+++ b/examples/multiselect_huge.rs
@@ -1,7 +1,7 @@
 use demand::{DemandOption, MultiSelect};
 
 fn main() {
-    let ms = MultiSelect::new("Toppings")
+    let multiselect = MultiSelect::new("Toppings")
         .description("Select your toppings")
         .min(1)
         .max(4)
@@ -67,5 +67,15 @@ fn main() {
         .option(DemandOption::new("Starburst"))
         .option(DemandOption::new("Twizzlers"))
         .option(DemandOption::new("Milk Duds"));
-    ms.run().expect("error running multi select");
+    let _ = match multiselect.run() {
+        Ok(value) => value,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                println!("Input cancelled");
+                return;
+            } else {
+                panic!("Error: {}", e);
+            }
+        }
+    };
 }

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -47,5 +47,15 @@ fn main() {
         .option(DemandOption::new("EG").label("Egypt"))
         .option(DemandOption::new("SA").label("Saudi Arabia"))
         .option(DemandOption::new("AE").label("United Arab Emirates"));
-    ms.run().expect("error running select");
+    let _ = match ms.run() {
+        Ok(value) => value,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                println!("Input cancelled");
+                return;
+            } else {
+                panic!("Error: {}", e);
+            }
+        }
+    };
 }

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -44,7 +44,7 @@ impl<'spinner> SpinnerActionRunner<'spinner> {
         &mut self, // with just this the compiler assumes that theme might be stored in self so it wont let u mutate it after this fn call
         theme: &'spinner Theme,
     ) -> Result<(), std::sync::mpsc::SendError<SpinnerAction>> {
-        let theme = unsafe { std::mem::transmute(theme) };
+        let theme = unsafe { std::mem::transmute::<&Theme, &Theme>(theme) };
         self.sender.send(SpinnerAction::Theme(theme))
     }
 
@@ -54,7 +54,7 @@ impl<'spinner> SpinnerActionRunner<'spinner> {
         &mut self, // with just this the compiler assumes that theme might be stored in self so it wont let u mutate it after this fn call
         style: &'spinner SpinnerStyle,
     ) -> Result<(), std::sync::mpsc::SendError<SpinnerAction>> {
-        let style = unsafe { std::mem::transmute(style) };
+        let style = unsafe { std::mem::transmute::<&SpinnerStyle, &SpinnerStyle>(style) };
         self.sender.send(SpinnerAction::Style(style))
     }
 


### PR DESCRIPTION
To not break any API contracts in terms of compatibility, throwing an error of type `io::ErrorKind::Interrupted` is probably the best option when cancelling the input.

Docs and examples also need to be updated to reflect this.