### PR TITLE
fix: ctrl-c doesn't restore cursor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ console = "0.15"
 fuzzy-matcher = "0.3"
 itertools = "0.13"
 once_cell = "1"
+signal-hook = "0.3"
 termcolor = "1"
 
 [dev-dependencies]

--- a/examples/confirm.rs
+++ b/examples/confirm.rs
@@ -5,11 +5,11 @@ fn main() {
         .description("This will do a thing.")
         .affirmative("Yes!")
         .negative("No.");
-    let _ = match confirm.run() {
+    match confirm.run() {
         Ok(confirm) => confirm,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::Interrupted {
-                println!("Dialog was cancelled");
+                println!("{}", e);
                 false
             } else {
                 panic!("Error: {}", e);

--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -9,11 +9,11 @@ fn main() {
             DialogButton::new("Cancel"),
         ])
         .selected_button(1);
-    let _ = match dialog.run() {
+    match dialog.run() {
         Ok(value) => value,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::Interrupted {
-                println!("Dialog was cancelled");
+                println!("{}", e);
                 return;
             } else {
                 panic!("Error: {}", e);

--- a/examples/input-password.rs
+++ b/examples/input-password.rs
@@ -5,11 +5,11 @@ fn main() {
         .placeholder("Enter password")
         .prompt("Password: ")
         .password(true);
-    let _ = match input.run() {
+    match input.run() {
         Ok(value) => value,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::Interrupted {
-                println!("Input cancelled");
+                println!("{}", e);
                 return;
             } else {
                 panic!("Error: {}", e);

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -26,11 +26,11 @@ fn main() {
             "Zack Snyder",
         ])
         .validation(notempty_minlen);
-    let _ = match input.run() {
+    match input.run() {
         Ok(value) => value,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::Interrupted {
-                println!("Input cancelled");
+                println!("{}", e);
                 return;
             } else {
                 panic!("Error: {}", e);

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -71,7 +71,7 @@ fn main() {
         Ok(_) => {}
         Err(e) => {
             if e.kind() == io::ErrorKind::Interrupted {
-                println!("Input cancelled");
+                println!("{}", e);
             } else {
                 panic!("Error: {}", e);
             }

--- a/examples/multiselect.rs
+++ b/examples/multiselect.rs
@@ -13,11 +13,11 @@ fn main() {
         .option(DemandOption::new("Cheese"))
         .option(DemandOption::new("Vegan Cheese"))
         .option(DemandOption::new("Nutella"));
-    let _ = match multiselect.run() {
+    match multiselect.run() {
         Ok(toppings) => toppings,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::Interrupted {
-                println!("Input cancelled");
+                println!("{}", e);
                 return;
             } else {
                 panic!("Error: {}", e);

--- a/examples/multiselect_huge.rs
+++ b/examples/multiselect_huge.rs
@@ -67,11 +67,11 @@ fn main() {
         .option(DemandOption::new("Starburst"))
         .option(DemandOption::new("Twizzlers"))
         .option(DemandOption::new("Milk Duds"));
-    let _ = match multiselect.run() {
+    match multiselect.run() {
         Ok(value) => value,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::Interrupted {
-                println!("Input cancelled");
+                println!("{}", e);
                 return;
             } else {
                 panic!("Error: {}", e);

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -47,11 +47,11 @@ fn main() {
         .option(DemandOption::new("EG").label("Egypt"))
         .option(DemandOption::new("SA").label("Saudi Arabia"))
         .option(DemandOption::new("AE").label("United Arab Emirates"));
-    let _ = match ms.run() {
+    match ms.run() {
         Ok(value) => value,
         Err(e) => {
             if e.kind() == std::io::ErrorKind::Interrupted {
-                println!("Input cancelled");
+                println!("{}", e);
                 return;
             } else {
                 panic!("Error: {}", e);

--- a/examples/themes.rs
+++ b/examples/themes.rs
@@ -2,6 +2,20 @@ use std::env::args;
 
 use demand::{Confirm, DemandOption, Input, MultiSelect, Theme};
 
+fn handle_run<T>(result: Result<T, std::io::Error>) -> T {
+    match result {
+        Ok(value) => value,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                println!("{}", e);
+                std::process::exit(0);
+            } else {
+                panic!("Error: {}", e);
+            }
+        }
+    }
+}
+
 fn main() {
     let theme = match args().nth(1).unwrap_or_default().as_str() {
         "base16" => Theme::base16(),
@@ -16,7 +30,7 @@ fn main() {
         .description("Please enter your e-mail address.")
         .placeholder("john.doe@acme.com")
         .theme(&theme);
-    i.run().expect("error running input");
+    handle_run(i.run());
 
     let ms = MultiSelect::new("Interests")
         .description("Select your interests")
@@ -31,12 +45,12 @@ fn main() {
         .option(DemandOption::new("Travel"))
         .option(DemandOption::new("Sports"))
         .theme(&theme);
-    ms.run().expect("error running multi select");
+    handle_run(ms.run());
 
     let c = Confirm::new("Confirm privacy policy")
         .description("Do you accept the privacy policy?")
         .affirmative("Yes")
         .negative("No")
         .theme(&theme);
-    c.run().expect("error running confirm");
+    handle_run(c.run());
 }

--- a/src/ctrlc.rs
+++ b/src/ctrlc.rs
@@ -1,0 +1,102 @@
+use console::Term;
+use once_cell::sync::Lazy;
+use signal_hook::{
+    consts::SIGINT,
+    iterator::{Handle, Signals},
+};
+use std::{
+    io::Error,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Mutex, RwLock,
+    },
+    thread,
+};
+
+static MUTEX: Mutex<()> = Mutex::new(());
+static INIT: AtomicBool = AtomicBool::new(false);
+static HANDLE: Lazy<RwLock<CtrlcHandle>> = Lazy::new(|| RwLock::new(CtrlcHandle(None)));
+
+#[derive(Clone)]
+pub struct CtrlcHandle(Option<Handle>);
+
+impl CtrlcHandle {
+    pub fn close(&self) {
+        if let Some(handle) = &self.0 {
+            handle.close();
+        }
+    }
+}
+
+/// Show cursor after Ctrl+C is pressed
+///
+/// The caller should call the close method of the returned handle to release the resources
+///
+/// # Arguments
+///
+/// * `term` - The terminal to show the cursor
+///
+/// # Returns
+///
+/// * `CtrlcHandle` - The handle to release the resources
+///
+/// # Errors
+///
+/// * `Error` - If failed to set the Ctrl+C handler
+///
+pub fn show_cursor_after_ctrlc(term: &Term) -> Result<CtrlcHandle, Error> {
+    let t = term.clone();
+    set_ctrlc_handler(move || {
+        let _ = t.show_cursor();
+    })
+}
+
+/// Set Ctrl+C handler
+///
+/// The caller should call the close method of the returned handle to release the resources
+///
+/// # Arguments
+///
+/// * `handler` - The handler to be called when Ctrl+C is pressed
+///
+/// # Returns
+///
+/// * `Result<Option<CtrlcHandle>, Error>` - The handle to release the resources
+///
+/// # Errors
+/// * `Error` - If failed to set the Ctrl+C handler
+///
+pub fn set_ctrlc_handler<F>(handler: F) -> Result<CtrlcHandle, Error>
+where
+    F: FnMut() + 'static + Send,
+{
+    let _mutex = MUTEX.lock();
+    if INIT.load(Ordering::Relaxed) {
+        let handle_guard = HANDLE.read().unwrap();
+        return Ok(handle_guard.clone());
+    }
+    INIT.store(true, Ordering::Relaxed);
+
+    let handle = set_ctrlc_handler_internal(handler)?;
+    {
+        let mut handle_guard = HANDLE.write().unwrap();
+        *handle_guard = CtrlcHandle(Some(handle.clone()));
+    }
+    Ok(CtrlcHandle(Some(handle)))
+}
+
+fn set_ctrlc_handler_internal<F>(mut handler: F) -> Result<Handle, Error>
+where
+    F: FnMut() + 'static + Send,
+{
+    let mut signals = Signals::new([SIGINT])?;
+    let handle = signals.handle();
+    thread::Builder::new()
+        .name("ctrl-c".into())
+        .spawn(move || {
+            for _ in signals.forever() {
+                handler();
+            }
+        })?;
+    Ok(handle)
+}

--- a/src/ctrlc_stub.rs
+++ b/src/ctrlc_stub.rs
@@ -1,0 +1,20 @@
+use std::io::Error;
+
+use console::Term;
+
+pub struct CtrlcHandle();
+
+impl CtrlcHandle {
+    pub fn close(&self) {}
+}
+
+pub fn show_cursor_after_ctrlc(_term: &Term) -> Result<CtrlcHandle, Error> {
+    Ok(CtrlcHandle())
+}
+
+pub fn set_ctrlc_handler<F>(_handler: F) -> Result<CtrlcHandle, Error>
+where
+    F: FnMut() + 'static + Send,
+{
+    Ok(CtrlcHandle())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ pub use spinner::SpinnerStyle;
 pub use theme::Theme;
 
 mod confirm;
+#[cfg_attr(any(windows), path = "ctrlc_stub.rs")]
+mod ctrlc;
 mod dialog;
 mod input;
 mod list;


### PR DESCRIPTION
Fixes #74 

- Confirm/Dialog currently don't hide the cursor which i think they should
- IMO behaviour of Escape and CTRL+C should be the same and not clear the terminal
- not sure about the current Spinner behaviour though