### PR TITLE
fix: prompt shows input history on every typed character

### DIFF
--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -1,5 +1,5 @@
+use std::io;
 use std::io::Write;
-use std::io::{self};
 
 use console::{Key, Term};
 use termcolor::{Buffer, WriteColor};
@@ -43,6 +43,7 @@ pub struct Confirm<'a> {
     pub selected: bool,
 
     term: Term,
+    height: usize,
 }
 
 impl<'a> Confirm<'a> {
@@ -56,6 +57,7 @@ impl<'a> Confirm<'a> {
             affirmative: "Yes".to_string(),
             negative: "No".to_string(),
             selected: true,
+            height: 0,
         }
     }
 
@@ -103,6 +105,7 @@ impl<'a> Confirm<'a> {
         loop {
             self.clear()?;
             let output = self.render()?;
+            self.height = output.lines().count() - 1;
             self.term.write_all(output.as_bytes())?;
             self.term.flush()?;
             match self.term.read_key()? {
@@ -219,7 +222,9 @@ impl<'a> Confirm<'a> {
     }
 
     fn clear(&mut self) -> io::Result<()> {
+        self.term.clear_last_lines(self.height)?;
         self.term.clear_screen()?;
+        self.height = 0;
         Ok(())
     }
 }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -68,6 +68,7 @@ pub struct Dialog<'a> {
     pub buttons: Vec<DialogButton>,
 
     term: Term,
+    height: usize,
     selected_button_idx: usize,
 }
 
@@ -82,6 +83,7 @@ impl<'a> Dialog<'a> {
             theme: &*theme::DEFAULT,
             term: Term::stderr(),
             buttons: vec![DialogButton::new("Ok"), DialogButton::new("Cancel")],
+            height: 0,
             selected_button_idx: 0,
         }
     }
@@ -135,6 +137,7 @@ impl<'a> Dialog<'a> {
         loop {
             self.clear()?;
             let output = self.render()?;
+            self.height = output.lines().count() - 1;
             self.term.write_all(output.as_bytes())?;
             self.term.flush()?;
             match self.term.read_key()? {
@@ -255,7 +258,9 @@ impl<'a> Dialog<'a> {
     }
 
     fn clear(&mut self) -> io::Result<()> {
+        self.term.clear_last_lines(self.height)?;
         self.term.clear_screen()?;
+        self.height = 0;
         Ok(())
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -54,6 +54,7 @@ pub struct Input<'a> {
 
     // Internal state
     cursor: usize,
+    height: usize,
     term: Term,
     err: Option<String>,
     suggestion: Option<String>,
@@ -81,6 +82,7 @@ impl<'a> Input<'a> {
 
             // Internal state
             cursor: 0,
+            height: 0,
             term: Term::stderr(),
             err: None,
             suggestion: None,
@@ -159,6 +161,7 @@ impl<'a> Input<'a> {
             self.clear()?;
             let output = self.render()?;
 
+            self.height = output.lines().count() - 1;
             self.term.write_all(output.as_bytes())?;
             self.term.flush()?;
             self.set_cursor()?;
@@ -495,7 +498,9 @@ impl<'a> Input<'a> {
     }
 
     fn clear(&mut self) -> io::Result<()> {
+        self.term.clear_last_lines(self.height)?;
         self.term.clear_screen()?;
+        self.height = 0;
         Ok(())
     }
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -53,6 +53,7 @@ pub struct List<'a> {
     filterable: bool,
     filter: String,
     cur_page: usize,
+    height: usize,
     pages: usize,
     scroll: usize,
 }
@@ -70,6 +71,7 @@ impl<'a> List<'a> {
             filtering: false,
             filterable: false,
             filter: String::new(),
+            height: 0,
             cur_page: 0,
             pages: 0,
             success_items: 4,
@@ -130,6 +132,7 @@ impl<'a> List<'a> {
             let output = self.render()?;
             self.term.write_all(output.as_bytes())?;
             self.term.flush()?;
+            self.height = output.lines().count() - 1;
             if self.filtering {
                 match self.term.read_key()? {
                     Key::Enter => self.handle_stop_filtering(true)?,
@@ -337,7 +340,13 @@ impl<'a> List<'a> {
     }
 
     fn clear(&mut self) -> Result<(), io::Error> {
+        if self.height > 0 {
+            self.term.clear_last_lines(self.height)?;
+        } else {
+            self.term.clear_line()?;
+        }
         self.term.clear_screen()?;
+        self.height = 0;
         Ok(())
     }
 }

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -65,6 +65,7 @@ pub struct MultiSelect<'a, T> {
     cursor_x: usize,
     cursor_y: usize,
     cursor: usize,
+    height: usize,
     term: Term,
     pages: usize,
     cur_page: usize,
@@ -87,6 +88,7 @@ impl<'a, T> MultiSelect<'a, T> {
             cursor_y: 0,
             err: None,
             cursor: 0,
+            height: 0,
             term: Term::stderr(),
             filter: String::new(),
             filtering: false,
@@ -173,6 +175,7 @@ impl<'a, T> MultiSelect<'a, T> {
             let output = self.render()?;
             self.term.write_all(output.as_bytes())?;
             self.term.flush()?;
+            self.height = output.lines().count() - 1;
             if self.filtering {
                 match self.term.read_key()? {
                     Key::ArrowLeft => self.handle_left()?,
@@ -606,7 +609,9 @@ impl<'a, T> MultiSelect<'a, T> {
     }
 
     fn clear(&mut self) -> io::Result<()> {
+        self.term.clear_last_lines(self.height)?;
         self.term.clear_screen()?;
+        self.height = 0;
         Ok(())
     }
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -53,6 +53,7 @@ pub struct Select<'a, T> {
 
     cursor_x: usize,
     cursor_y: usize,
+    height: usize,
     term: Term,
     filter: String,
     filtering: bool,
@@ -73,6 +74,7 @@ impl<'a, T> Select<'a, T> {
             theme: &theme::DEFAULT,
             cursor_x: 0,
             cursor_y: 0,
+            height: 0,
             term: Term::stderr(),
             filter: String::new(),
             filtering: false,
@@ -141,6 +143,7 @@ impl<'a, T> Select<'a, T> {
             self.term.write_all(output.as_bytes())?;
             self.term.flush()?;
             self.term.hide_cursor()?;
+            self.height = output.lines().count() - 1;
             let enter = |mut select: Select<T>| {
                 select.clear()?;
                 select.term.show_cursor()?;
@@ -482,7 +485,9 @@ impl<'a, T> Select<'a, T> {
     }
 
     fn clear(&mut self) -> io::Result<()> {
+        self.term.clear_last_lines(self.height)?;
         self.term.clear_screen()?;
+        self.height = 0;
         Ok(())
     }
 }

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -92,6 +92,7 @@ pub struct Spinner<'a> {
 
     term: Term,
     frame: usize,
+    height: usize,
 }
 
 impl<'a> Spinner<'a> {
@@ -103,6 +104,7 @@ impl<'a> Spinner<'a> {
             theme: &theme::DEFAULT,
             term: Term::stderr(),
             frame: 0,
+            height: 0,
         }
     }
 
@@ -157,6 +159,7 @@ impl<'a> Spinner<'a> {
                 }
                 self.clear()?;
                 let output = self.render()?;
+                self.height = output.lines().count() - 1;
                 self.term.write_all(output.as_bytes())?;
                 sleep(self.style.fps);
                 if handle.is_finished() {
@@ -191,7 +194,13 @@ impl<'a> Spinner<'a> {
     }
 
     fn clear(&mut self) -> io::Result<()> {
+        if self.height == 0 {
+            self.term.clear_line()?;
+        } else {
+            self.term.clear_last_lines(self.height)?;
+        }
         self.term.clear_screen()?;
+        self.height = 0;
         Ok(())
     }
 }


### PR DESCRIPTION
Fixes #94 by reverting commit [3483342](https://github.com/jdx/demand/commit/34833425a3fdbd2c8423e9fe518ce62aca951d87) but adding the clear screen behaviour