### PR TITLE
fix: support non-TTY input for automated testing

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -169,6 +169,24 @@ impl<'a> Input<'a> {
     /// This function will block until the user submits the input. If the user cancels the input,
     /// an error of type `io::ErrorKind::Interrupted` is returned.
     pub fn run(mut self) -> io::Result<String> {
+        // If not a TTY (e.g., piped input), read from stdin directly
+        if !self.term.is_term() {
+            use std::io::BufRead;
+            let stdin = io::stdin();
+            let mut line = String::new();
+            stdin.lock().read_line(&mut line)?;
+            // Remove trailing newline
+            self.input = line.trim_end().to_string();
+            self.validate()?;
+            if self.err.is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    self.err.unwrap(),
+                ));
+            }
+            return Ok(self.input);
+        }
+
         let ctrlc_handle = ctrlc::show_cursor_after_ctrlc(&self.term)?;
 
         self.term.hide_cursor()?;

--- a/src/input.rs
+++ b/src/input.rs
@@ -176,7 +176,7 @@ impl<'a> Input<'a> {
             let mut line = String::new();
             stdin.lock().read_line(&mut line)?;
             // Remove trailing newline
-            self.input = line.trim_end().to_string();
+            self.input = line.strip_suffix('\n').unwrap_or(&line).to_string();
             self.validate()?;
             if self.err.is_some() {
                 return Err(io::Error::new(

--- a/src/input.rs
+++ b/src/input.rs
@@ -175,8 +175,15 @@ impl<'a> Input<'a> {
             let stdin = io::stdin();
             let mut line = String::new();
             stdin.lock().read_line(&mut line)?;
-            // Remove trailing newline
-            self.input = line.strip_suffix('\n').unwrap_or(&line).to_string();
+            // Remove trailing line endings (handles both \n and \r\n for Windows)
+            let mut input = line.as_str();
+            if let Some(stripped) = input.strip_suffix('\n') {
+                input = stripped;
+            }
+            if let Some(stripped) = input.strip_suffix('\r') {
+                input = stripped;
+            }
+            self.input = input.to_string();
             self.validate()?;
             if self.err.is_some() {
                 return Err(io::Error::new(

--- a/src/test.rs
+++ b/src/test.rs
@@ -6,6 +6,6 @@ fn init() {
     console::set_colors_enabled_stderr(false);
 }
 
-pub fn without_ansi(s: &str) -> Cow<str> {
+pub fn without_ansi(s: &str) -> Cow<'_, str> {
     console::strip_ansi_codes(s)
 }

--- a/tests/non_tty_input.rs
+++ b/tests/non_tty_input.rs
@@ -1,0 +1,63 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[test]
+fn test_piped_stdin() {
+    // Run the input example with piped stdin (non-TTY)
+    // The example has validation requiring 8+ chars, so use a valid value
+    let mut child = Command::new("cargo")
+        .args(&["run", "--quiet", "--example", "input"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn example");
+
+    // Write test value to stdin that passes validation (8+ chars)
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(b"TestValue123\n")
+            .expect("Failed to write to stdin");
+    }
+
+    // Wait for completion and get output
+    let output = child
+        .wait_with_output()
+        .expect("Failed to wait for example");
+
+    // Should exit successfully (validation passed)
+    assert!(
+        output.status.success(),
+        "Example should exit successfully with valid input, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_piped_stdin_validation_failure() {
+    // Test that validation errors are handled correctly with piped input
+    let mut child = Command::new("cargo")
+        .args(&["run", "--quiet", "--example", "input"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn example");
+
+    // Write a value that fails validation (too short - needs 8+ chars)
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(b"short\n")
+            .expect("Failed to write to stdin");
+    }
+
+    let output = child
+        .wait_with_output()
+        .expect("Failed to wait for example");
+
+    // Should fail validation
+    assert!(
+        !output.status.success(),
+        "Example should fail with invalid input (too short)"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds support for non-TTY stdin (e.g., piped input) to enable automated testing
- When stdin is not a TTY, reads directly from stdin instead of terminal
- Maintains full interactive behavior when stdin is a TTY

## Problem
The `Input` widget only worked with interactive terminals (TTYs), making it impossible to test prompts in automated test scripts. Commands like:

```bash
echo "test-value" | my-app --prompt
```

Would hang because `term.read_key()` tries to read from the terminal, not stdin.

## Solution
Added detection at the start of `Input::run()` to check if stdin is a TTY using `term.is_term()`. When not a TTY:
1. Read one line from stdin using `BufRead::read_line()`
2. Trim trailing newline
3. Validate the input
4. Return the value or validation error

When stdin is a TTY, behavior is unchanged - full interactive prompt with cursor control.

## Use Case
This enables test scripts to provide input to prompts:

```bash
# Test script
echo "password123" | myapp set-secret --prompt

# Or in a test file
RESULT=$(echo "value" | myapp prompt-command)
assert_equals "$RESULT" "value"
```

## Testing
Tested with mise's `mise set --prompt` command:
- Manual testing: Interactive prompts work normally
- Automated testing: `echo "value" | mise set VAR --prompt` works correctly
- E2E tests pass with piped input

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds non-TTY stdin handling to `Input::run` (read, trim, validate) and introduces tests for piped input, validation failure, and CRLF; minor lifetime tweak in `without_ansi`.
> 
> - **Input handling**:
>   - Update `src/input.rs` `Input::run` to detect non-TTY via `term.is_term()` and, when false, read one line from `stdin`, strip `\n`/`\r`, validate, and return the result or `InvalidInput`.
> - **Tests**:
>   - Add `tests/non_tty_input.rs` with cases for piped stdin success, validation failure, and Windows `\r\n` handling against the `input` example.
> - **Misc**:
>   - Adjust `src/test.rs` `without_ansi` return type to `Cow<'_, str>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74bfbe2a2c70b2720deacddea506818ed52be49c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->