### PR TITLE
chore: release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.0.1](https://github.com/jdx/demand/compare/v2.0.0...v2.0.1) - 2026-04-17
+
+### Other
+
+- *(deps)* update dependency hk to v1.43.0 ([#152](https://github.com/jdx/demand/pull/152))
+- *(deps)* update rust crate ctor to 0.10 ([#153](https://github.com/jdx/demand/pull/153))
+- *(deps)* update rust crate ctor to 0.9 ([#150](https://github.com/jdx/demand/pull/150))
+
 ## [2.0.0](https://github.com/jdx/demand/compare/v1.8.2...v2.0.0) - 2026-03-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.0.1](https://github.com/jdx/demand/compare/v2.0.0...v2.0.1) - 2026-05-05
+
+### Fixed
+
+- *(multiselect)* stop menu from drifting up on each keypress ([#156](https://github.com/jdx/demand/pull/156))
+
+### Other
+
+- *(deps)* update dependency hk to v1.43.0 ([#152](https://github.com/jdx/demand/pull/152))
+- *(deps)* update rust crate ctor to 0.10 ([#153](https://github.com/jdx/demand/pull/153))
+- *(deps)* update rust crate ctor to 0.9 ([#150](https://github.com/jdx/demand/pull/150))
+
 ## [2.0.0](https://github.com/jdx/demand/compare/v1.8.2...v2.0.0) - 2026-03-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demand"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 description = "A CLI prompt library"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `demand`: 2.0.0 -> 2.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.1](https://github.com/jdx/demand/compare/v2.0.0...v2.0.1) - 2026-05-05

### Fixed

- *(multiselect)* stop menu from drifting up on each keypress ([#156](https://github.com/jdx/demand/pull/156))

### Other

- *(deps)* update dependency hk to v1.43.0 ([#152](https://github.com/jdx/demand/pull/152))
- *(deps)* update rust crate ctor to 0.10 ([#153](https://github.com/jdx/demand/pull/153))
- *(deps)* update rust crate ctor to 0.9 ([#150](https://github.com/jdx/demand/pull/150))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps the crate version and updates the changelog; no functional code changes are included in the diff.
> 
> **Overview**
> Prepares the `v2.0.1` release by bumping `Cargo.toml` from `2.0.0` to `2.0.1` and adding a `2.0.1` entry to `CHANGELOG.md` documenting the multiselect drift fix and dependency updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2cdb07ce438a6dd8ab6cb0b767d92b003a48518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->