### PR TITLE
chore: set dev profile debug to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ termcolor = "1"
 ctor = "0.10"
 indoc = "2"
 insta = "1"
+
+[profile.dev]
+debug = 1


### PR DESCRIPTION
## Summary

Reduces `target/` disk usage by setting `[profile.dev] debug = 1`, while keeping backtrace file:line info intact.

The default `debug = 2` writes full DWARF — including variable/type info that's only needed when stepping through code in a debugger (lldb/gdb). With `debug = 1`, panics, `RUST_BACKTRACE=1`, and error chains still resolve to file:line; only debugger variable inspection is reduced.

In practice this typically shrinks `target/` by a meaningful percentage, which adds up across worktrees.

## Test plan

- [ ] `cargo build` still succeeds
- [ ] CI is green

---
*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects dev build artifacts and debug info generation, not runtime behavior or release builds.
> 
> **Overview**
> Updates `Cargo.toml` to add `[profile.dev] debug = 1`, reducing the amount of debug information generated in dev builds (smaller `target/` output) while still retaining file/line backtraces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2355e49f80f00f6536c6e86a846874b52f54c1b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->