### PR TITLE
chore: release v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.0.2](https://github.com/jdx/demand/compare/v2.0.1...v2.0.2) - 2026-05-17
+
+### Fixed
+
+- allow ArrowUp/ArrowDown/Space during filtering in multiselect ([#164](https://github.com/jdx/demand/pull/164))
+
+### Other
+
+- *(deps)* update rust crate ctor to v1 ([#163](https://github.com/jdx/demand/pull/163))
+- *(deps)* update release-plz/action digest to 064f4d1 ([#160](https://github.com/jdx/demand/pull/160))
+- *(deps)* update dependency hk to v1.45.0 ([#161](https://github.com/jdx/demand/pull/161))
+- *(deps)* update rust crate ctor to 0.12 ([#159](https://github.com/jdx/demand/pull/159))
+
 ## [2.0.1](https://github.com/jdx/demand/compare/v2.0.0...v2.0.1) - 2026-05-05
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demand"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 description = "A CLI prompt library"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `demand`: 2.0.1 -> 2.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.2](https://github.com/jdx/demand/compare/v2.0.1...v2.0.2) - 2026-05-17

### Fixed

- allow ArrowUp/ArrowDown/Space during filtering in multiselect ([#164](https://github.com/jdx/demand/pull/164))

### Other

- *(deps)* update rust crate ctor to v1 ([#163](https://github.com/jdx/demand/pull/163))
- *(deps)* update release-plz/action digest to 064f4d1 ([#160](https://github.com/jdx/demand/pull/160))
- *(deps)* update dependency hk to v1.45.0 ([#161](https://github.com/jdx/demand/pull/161))
- *(deps)* update rust crate ctor to 0.12 ([#159](https://github.com/jdx/demand/pull/159))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata update only: bumps the crate version and appends release notes, with no functional code changes in this PR.
> 
> **Overview**
> Prepares the `v2.0.2` release by bumping the crate version in `Cargo.toml` and adding a new `2.0.2` section to `CHANGELOG.md`.
> 
> The changelog notes a multiselect filtering key-handling fix (ArrowUp/ArrowDown/Space) and dependency/release workflow updates, but the PR itself only updates release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d57691c64ae00df59112716afb76c3e31c658e03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->