### PR TITLE
chore: release v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2.0.3](https://github.com/jdx/demand/compare/v2.0.2...v2.0.3) - 2026-07-03
+
+### Fixed
+
+- *(deps)* update rust crate itertools to 0.15 ([#176](https://github.com/jdx/demand/pull/176))
+- Enter in filtering mode now confirms selection in MultiSelect ([#165](https://github.com/jdx/demand/pull/165))
+
+### Other
+
+- *(deps)* update dependency hk to v1.49.0 ([#180](https://github.com/jdx/demand/pull/180))
+- *(deps)* update dtolnay/rust-toolchain digest to 4be7066 ([#179](https://github.com/jdx/demand/pull/179))
+- Update sponsor references for jdx.dev ([#178](https://github.com/jdx/demand/pull/178))
+- *(deps)* update actions/checkout action to v7 ([#177](https://github.com/jdx/demand/pull/177))
+- Enable Entire for Codex ([#175](https://github.com/jdx/demand/pull/175))
+- *(deps)* update dependency hk to v1.48.0 ([#174](https://github.com/jdx/demand/pull/174))
+- *(deps)* update jdx/mise-action digest to e6a8b39 ([#173](https://github.com/jdx/demand/pull/173))
+- link to all sponsors ([#172](https://github.com/jdx/demand/pull/172))
+- *(deps)* update release-plz/action digest to e879257 ([#171](https://github.com/jdx/demand/pull/171))
+- *(deps)* update jdx/mise-action digest to dba1968 ([#168](https://github.com/jdx/demand/pull/168))
+- *(deps)* update actions/checkout digest to df4cb1c ([#167](https://github.com/jdx/demand/pull/167))
+- *(deps)* update dependency hk to v1.46.0 ([#169](https://github.com/jdx/demand/pull/169))
+
 ## [2.0.2](https://github.com/jdx/demand/compare/v2.0.1...v2.0.2) - 2026-05-17
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demand"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2024"
 description = "A CLI prompt library"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `demand`: 2.0.2 -> 2.0.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.3](https://github.com/jdx/demand/compare/v2.0.2...v2.0.3) - 2026-07-03

### Fixed

- *(deps)* update rust crate itertools to 0.15 ([#176](https://github.com/jdx/demand/pull/176))
- Enter in filtering mode now confirms selection in MultiSelect ([#165](https://github.com/jdx/demand/pull/165))

### Other

- *(deps)* update dependency hk to v1.49.0 ([#180](https://github.com/jdx/demand/pull/180))
- *(deps)* update dtolnay/rust-toolchain digest to 4be7066 ([#179](https://github.com/jdx/demand/pull/179))
- Update sponsor references for jdx.dev ([#178](https://github.com/jdx/demand/pull/178))
- *(deps)* update actions/checkout action to v7 ([#177](https://github.com/jdx/demand/pull/177))
- Enable Entire for Codex ([#175](https://github.com/jdx/demand/pull/175))
- *(deps)* update dependency hk to v1.48.0 ([#174](https://github.com/jdx/demand/pull/174))
- *(deps)* update jdx/mise-action digest to e6a8b39 ([#173](https://github.com/jdx/demand/pull/173))
- link to all sponsors ([#172](https://github.com/jdx/demand/pull/172))
- *(deps)* update release-plz/action digest to e879257 ([#171](https://github.com/jdx/demand/pull/171))
- *(deps)* update jdx/mise-action digest to dba1968 ([#168](https://github.com/jdx/demand/pull/168))
- *(deps)* update actions/checkout digest to df4cb1c ([#167](https://github.com/jdx/demand/pull/167))
- *(deps)* update dependency hk to v1.46.0 ([#169](https://github.com/jdx/demand/pull/169))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version and changelog metadata change; no library source in this PR diff.
> 
> **Overview**
> Bumps **demand** from `2.0.2` to **`2.0.3`** via release-plz: updates `Cargo.toml` and adds the **2.0.3** section to `CHANGELOG.md`.
> 
> User-facing fixes called out in the changelog include **Enter confirming selection while filtering in MultiSelect** and bumping **itertools** to 0.15; the rest of the listed items are CI, tooling, and sponsor/doc updates from merged PRs since the last release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99fa8f3047801a23c1f7b6e7a63989bdc8913f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->