### PR TITLE
docs: link to all sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 A prompt library for Rust. Based on [huh? for Go](https://github.com/charmbracelet/huh). Maintained by [@jdx](https://github.com/jdx) and [@roele](https://github.com/roele).
 
+## Sponsors
+
+[View all sponsors](https://en.dev/sponsors.html).
+
 ## Input
 
 * Single-line text input with variable prompt and placeholder


### PR DESCRIPTION
## Summary
- add a README link to the full en.dev sponsors page

## Tests
- not run (README-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code or runtime impact.
> 
> **Overview**
> Adds a **Sponsors** section near the top of the README, right after the project intro, with a link to the full sponsors list at `https://en.dev/sponsors.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a325a3856fc5c8a3dbf168fe1403227989129454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Sponsors" section to the README with a link to view all sponsors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->