### PR TITLE
Update sponsor references for jdx.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ A prompt library for Rust. Based on [huh? for Go](https://github.com/charmbracel
 
 ## Sponsors
 
-[View all sponsors](https://en.dev/sponsors.html).
+demand is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), [CodeRabbit](https://coderabbit.link/mise), and [Supabase](https://supabase.com).
+
+[View all sponsors](https://jdx.dev/sponsors.html).
 
 ## Input
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A prompt library for Rust. Based on [huh? for Go](https://github.com/charmbracel
 
 ## Sponsors
 
-demand is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), and [CodeRabbit](https://coderabbit.link/mise).
+demand is sponsored by [entire.io](https://entire.io) and [37signals](https://37signals.com).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A prompt library for Rust. Based on [huh? for Go](https://github.com/charmbracel
 
 ## Sponsors
 
-demand is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), [CodeRabbit](https://coderabbit.link/mise), and [Supabase](https://supabase.com).
+demand is sponsored by [entire.io](https://entire.io), [37signals](https://37signals.com), and [CodeRabbit](https://coderabbit.link/mise).
 
 [View all sponsors](https://jdx.dev/sponsors.html).
 


### PR DESCRIPTION
## Summary
- list Entire first in the README sponsor copy
- point sponsor links at jdx.dev

## Tests
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README changes with no runtime or security impact.
> 
> **Overview**
> Updates the **Sponsors** section in `README.md` to name [entire.io](https://entire.io) before [37signals](https://37signals.com) and to send the “View all sponsors” link to `https://jdx.dev/sponsors.html` instead of `https://en.dev/sponsors.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ae7c6f15a65336a4535385d2592dd3dfd991050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->