### PR TITLE
fix: clear wrapped lines when redrawing a prompt

### DIFF
--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -200,7 +200,7 @@ impl<'a> Confirm<'a> {
         loop {
             self.clear()?;
             let output = self.render()?;
-            self.height = output.lines().count() - 1;
+            self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
             self.term.write_all(output.as_bytes())?;
             self.term.flush()?;
             match self.term.read_key()? {

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -145,7 +145,7 @@ impl<'a> Dialog<'a> {
         loop {
             self.clear()?;
             let output = self.render()?;
-            self.height = output.lines().count() - 1;
+            self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
             self.term.write_all(output.as_bytes())?;
             self.term.flush()?;
             match self.term.read_key()? {

--- a/src/height.rs
+++ b/src/height.rs
@@ -1,0 +1,75 @@
+/// Number of physical terminal rows a rendered frame occupies in a
+/// terminal `width` columns wide.
+///
+/// Widgets redraw by clearing the previous frame with
+/// `Term::clear_last_lines`, which counts *physical* rows. Counting
+/// logical lines instead leaves the wrapped remainder of any over-wide
+/// line on screen, and the next frame draws below the leftovers — so the
+/// prompt appears to duplicate itself, once per keypress.
+///
+/// What's counted is the rows *above* the cursor, since that's where a
+/// frame leaves it: everything before the final newline. The text after
+/// that newline — the color reset every widget writes last, or nothing at
+/// all — is the row the cursor rests on, not a row to clear. Splitting on
+/// `'\n'` rather than using `lines()` makes both endings behave the same;
+/// `lines()` swallows a trailing empty segment and would lose a row when
+/// the reset is absent.
+pub(crate) fn rendered_height(output: &str, width: usize) -> usize {
+    let mut lines: Vec<&str> = output.split('\n').collect();
+    // Whatever follows the last newline is the row the cursor rests on.
+    lines.pop();
+    lines.iter().map(|line| rows_for(line, width)).sum()
+}
+
+/// Rows one logical line wraps into. A line exactly `width` wide still
+/// occupies a single row — terminals defer the wrap until the next
+/// character arrives.
+fn rows_for(line: &str, width: usize) -> usize {
+    let printed = console::measure_text_width(line);
+    if width == 0 || printed <= width {
+        1
+    } else {
+        printed.div_ceil(width)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rendered_height;
+
+    /// The trailing reset fragment is not a row.
+    #[test]
+    fn drops_the_trailing_reset_fragment() {
+        assert_eq!(rendered_height("title\noption\n\x1b[0m", 80), 2);
+    }
+
+    #[test]
+    fn counts_a_line_that_fits_as_one_row() {
+        assert_eq!(rendered_height("12345678\n\x1b[0m", 8), 1);
+    }
+
+    #[test]
+    fn counts_the_rows_an_over_wide_line_wraps_into() {
+        // 9 and 17 columns in an 8-column terminal: two rows, then three.
+        assert_eq!(rendered_height("123456789\n\x1b[0m", 8), 2);
+        assert_eq!(
+            rendered_height(&format!("{}\n\x1b[0m", "x".repeat(17)), 8),
+            3
+        );
+    }
+
+    /// Color codes are not printed, so they must not push a line into a
+    /// second row.
+    #[test]
+    fn measures_printed_width_not_byte_length() {
+        let colored = format!("\x1b[38;5;252m{}\x1b[0m\n\x1b[0m", "x".repeat(8));
+        assert_eq!(rendered_height(&colored, 8), 1);
+    }
+
+    /// An unknown terminal width can't wrap anything, so fall back to the
+    /// old logical-line count rather than dividing by zero.
+    #[test]
+    fn treats_zero_width_as_one_row_per_line() {
+        assert_eq!(rendered_height("aaaa\nbbbb\n\x1b[0m", 0), 2);
+    }
+}

--- a/src/height.rs
+++ b/src/height.rs
@@ -21,6 +21,15 @@ pub(crate) fn rendered_height(output: &str, width: usize) -> usize {
     lines.iter().map(|line| rows_for(line, width)).sum()
 }
 
+/// Every row a frame occupies, including the one the cursor rests on.
+///
+/// For widgets whose frame ends without a newline — the spinner writes a
+/// single line and leaves the cursor at the end of it — the last row is
+/// part of the frame and has to be cleared like any other.
+pub(crate) fn rendered_rows(output: &str, width: usize) -> usize {
+    output.split('\n').map(|line| rows_for(line, width)).sum()
+}
+
 /// Rows one logical line wraps into. A line exactly `width` wide still
 /// occupies a single row — terminals defer the wrap until the next
 /// character arrives.
@@ -71,5 +80,16 @@ mod tests {
     #[test]
     fn treats_zero_width_as_one_row_per_line() {
         assert_eq!(rendered_height("aaaa\nbbbb\n\x1b[0m", 0), 2);
+    }
+
+    /// A frame with no trailing newline — the spinner — is entirely above
+    /// nothing: `rendered_height` sees no rows to clear, `rendered_rows`
+    /// counts the row the cursor is sitting in.
+    #[test]
+    fn rendered_rows_counts_a_frame_the_cursor_sits_inside() {
+        use super::rendered_rows;
+        assert_eq!(rendered_height("/ Loading", 80), 0);
+        assert_eq!(rendered_rows("/ Loading", 80), 1);
+        assert_eq!(rendered_rows(&format!("/ {}", "x".repeat(100)), 80), 2);
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -377,7 +377,7 @@ impl<'a> Input<'a> {
             self.clear()?;
             let output = self.render()?;
 
-            self.height = output.lines().count() - 1;
+            self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
             self.term.write_all(output.as_bytes())?;
             self.term.flush()?;
             self.set_cursor()?;

--- a/src/input.rs
+++ b/src/input.rs
@@ -600,15 +600,17 @@ impl<'a> Input<'a> {
         }
         out.reset()?;
 
-        self.input_line_offset = if self.inline {
-            0
-        } else {
-            let mut offset = 1;
-            if !self.description.is_empty() {
-                offset += 1;
-            }
-            offset
-        };
+        // Rows above the input row. Everything written so far is the
+        // header plus the prompt, and the prompt shares the input's row —
+        // which is exactly what `rendered_height` excludes, so it gives
+        // the header's height directly. Counting rows rather than lines
+        // matters because `self.height` is in rows: subtracting a logical
+        // line count from it would put the caret on the wrong row as soon
+        // as a title or description wrapped. Inline mode writes no
+        // newline at all and correctly comes out as 0.
+        let header = std::str::from_utf8(out.as_slice()).unwrap_or_default();
+        self.input_line_offset =
+            crate::height::rendered_height(header, self.term.size().1 as usize);
 
         self.render_input(&mut out)?;
         writeln!(out)?;
@@ -1086,5 +1088,28 @@ mod tests {
             "Password ************\n",
             without_ansi(input.render_success().unwrap().as_str())
         );
+    }
+
+    /// `input_line_offset` is subtracted from `self.height`, which counts
+    /// physical rows — so it has to count rows too. A title that wraps
+    /// occupies two of them, and counting it as one logical line would
+    /// put the caret a row above where the input actually is.
+    #[test]
+    fn input_line_offset_counts_rows_not_lines() {
+        let mut input = Input::new("t".repeat(200)).description("d");
+        input.render().unwrap();
+        let width = input.term.size().1 as usize;
+        let title_rows = 200_usize.div_ceil(width);
+        assert!(title_rows > 1, "test needs a title wider than the terminal");
+        assert_eq!(input.input_line_offset, title_rows + 1);
+    }
+
+    /// Inline mode writes no newline before the input, so nothing sits
+    /// above it.
+    #[test]
+    fn inline_input_has_no_rows_above_it() {
+        let mut input = Input::new("Name").inline(true);
+        input.render().unwrap();
+        assert_eq!(input.input_line_offset, 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod confirm;
 #[cfg_attr(any(windows), path = "ctrlc_stub.rs")]
 mod ctrlc;
 mod dialog;
+mod height;
 mod input;
 mod list;
 mod multiselect;

--- a/src/list.rs
+++ b/src/list.rs
@@ -132,7 +132,7 @@ impl<'a> List<'a> {
             let output = self.render()?;
             self.term.write_all(output.as_bytes())?;
             self.term.flush()?;
-            self.height = output.lines().count() - 1;
+            self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
             if self.filtering {
                 match self.term.read_key()? {
                     Key::Enter => self.handle_stop_filtering(true)?,

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -712,66 +712,11 @@ impl<'a, T> MultiSelect<'a, T> {
 #[cfg(test)]
 mod tests {
     use crate::test::without_ansi;
+    #[cfg(unix)]
+    use crate::test::{capture_term, snapshot};
 
     use super::*;
     use indoc::indoc;
-
-    // The redraw regression tests below use `Term::read_write_pair`, which is
-    // `#[cfg(unix)]` in the console crate. CI also runs on Windows, where this
-    // module simply has no test seam — the bug was reported on Linux/macOS and
-    // the fix is platform-agnostic, so the unix-only tests are sufficient.
-    #[cfg(unix)]
-    use std::fs::{File, OpenOptions};
-    #[cfg(unix)]
-    use std::os::fd::{AsRawFd, RawFd};
-    #[cfg(unix)]
-    use std::sync::{Arc, Mutex};
-
-    /// `Term::read_write_pair` is bounded by `Write + Debug + AsRawFd + Send +
-    /// 'static`. It only uses the fd for its own `AsRawFd` impl — the actual
-    /// I/O goes through `Write::write_all` — so we can satisfy the trait by
-    /// holding a throwaway `/dev/null` handle and capture bytes into a shared
-    /// `Vec` without any kernel round-trip.
-    #[cfg(unix)]
-    #[derive(Debug)]
-    struct CaptureWriter {
-        _fd: File,
-        bytes: Arc<Mutex<Vec<u8>>>,
-    }
-
-    #[cfg(unix)]
-    impl Write for CaptureWriter {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.bytes.lock().unwrap().extend_from_slice(buf);
-            Ok(buf.len())
-        }
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
-    #[cfg(unix)]
-    impl AsRawFd for CaptureWriter {
-        fn as_raw_fd(&self) -> RawFd {
-            self._fd.as_raw_fd()
-        }
-    }
-
-    #[cfg(unix)]
-    fn capture_term() -> (Term, Arc<Mutex<Vec<u8>>>) {
-        let bytes = Arc::new(Mutex::new(Vec::new()));
-        let writer = CaptureWriter {
-            _fd: OpenOptions::new().write(true).open("/dev/null").unwrap(),
-            bytes: Arc::clone(&bytes),
-        };
-        let reader = File::open("/dev/null").unwrap();
-        (Term::read_write_pair(reader, writer), bytes)
-    }
-
-    #[cfg(unix)]
-    fn snapshot(buf: &Arc<Mutex<Vec<u8>>>) -> Vec<u8> {
-        buf.lock().unwrap().clone()
-    }
 
     #[test]
     fn test_render() {

--- a/src/select.rs
+++ b/src/select.rs
@@ -139,11 +139,8 @@ impl<'a, T> Select<'a, T> {
 
         loop {
             self.clear()?;
-            let output = self.render()?;
-            self.term.write_all(output.as_bytes())?;
-            self.term.flush()?;
+            self.draw()?;
             self.term.hide_cursor()?;
-            self.height = output.lines().count() - 1;
             let enter = |mut select: Select<T>| {
                 select.clear()?;
                 select.term.show_cursor()?;
@@ -487,6 +484,16 @@ impl<'a, T> Select<'a, T> {
         Ok(std::str::from_utf8(out.as_slice()).unwrap().to_string())
     }
 
+    /// Render a frame, write it out, and record how many rows it took so
+    /// the next `clear` erases exactly that much.
+    fn draw(&mut self) -> io::Result<()> {
+        let output = self.render()?;
+        self.term.write_all(output.as_bytes())?;
+        self.term.flush()?;
+        self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
+        Ok(())
+    }
+
     fn clear(&mut self) -> io::Result<()> {
         self.term.clear_last_lines(self.height)?;
         self.height = 0;
@@ -497,6 +504,8 @@ impl<'a, T> Select<'a, T> {
 #[cfg(test)]
 mod tests {
     use crate::test::without_ansi;
+    #[cfg(unix)]
+    use crate::test::{capture_term, snapshot};
 
     use super::*;
     use indoc::indoc;
@@ -566,6 +575,56 @@ mod tests {
             "
             },
             without_ansi(select.render().unwrap().as_str())
+        );
+    }
+
+    /// Regression for the wrapped-line redraw bug (jdx/aube#1107): an
+    /// option wider than the terminal wraps into physical rows that
+    /// `clear_last_lines` never erased, because the height was counted in
+    /// logical lines. Every keypress then drew a fresh frame below the
+    /// leftovers, so the prompt visibly duplicated itself.
+    ///
+    /// Drives three redraw cycles through a captured `Term`, replays the
+    /// bytes through a vt100 emulator, and asserts the screen holds one
+    /// copy of the prompt.
+    #[cfg(unix)]
+    #[test]
+    fn a_wrapped_option_does_not_stack_copies_of_the_frame() {
+        let (term, buf) = capture_term();
+        let mut select = Select::new("Pick a script")
+            .option(DemandOption::new("long").label(&"x".repeat(140)))
+            .option(DemandOption::new("short"));
+        select.term = term;
+        let width = select.term.size().1 as usize;
+        // The label has to actually exceed the terminal for this to test
+        // anything.
+        assert!(width < 140, "test needs a label wider than the terminal");
+
+        for i in 0..3 {
+            select.clear().unwrap();
+            select.draw().unwrap();
+            // Move the cursor so consecutive frames differ and the redraw
+            // path has real work to do.
+            select.cursor_y = i % select.options.len();
+        }
+
+        let mut parser = vt100::Parser::new(24, width as u16, 0);
+        // A real terminal maps the widget's `\n` to CR+LF (ONLCR); the
+        // emulator doesn't, and without it the cursor keeps its column and
+        // the row math is meaningless.
+        let mut bytes = Vec::new();
+        for b in snapshot(&buf) {
+            if b == b'\n' {
+                bytes.push(b'\r');
+            }
+            bytes.push(b);
+        }
+        parser.process(&bytes);
+        let screen = parser.screen().contents();
+        assert_eq!(
+            screen.matches("Pick a script").count(),
+            1,
+            "prompt drawn more than once:\n{screen}"
         );
     }
 }

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -161,7 +161,10 @@ impl<'a> Spinner<'a> {
                 }
                 self.clear()?;
                 let output = self.render()?;
-                self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
+                // `rendered_rows`, not `rendered_height`: the spinner frame
+                // has no trailing newline, so the cursor sits on its last
+                // row and that row counts.
+                self.height = crate::height::rendered_rows(&output, self.term.size().1 as usize);
                 self.term.write_all(output.as_bytes())?;
                 sleep(self.style.fps);
                 if handle.is_finished() {
@@ -195,12 +198,18 @@ impl<'a> Spinner<'a> {
         Ok(std::str::from_utf8(out.as_slice()).unwrap().to_string())
     }
 
+    /// Wipe the frame the cursor is currently sitting in.
+    ///
+    /// Not `clear_last_lines`: that clears the rows *above* the cursor,
+    /// and the spinner's cursor is inside its own frame rather than below
+    /// it. So walk up from the last row, clearing as we go. A frame that
+    /// didn't wrap is a single `clear_line`, exactly as before.
     fn clear(&mut self) -> io::Result<()> {
-        if self.height == 0 {
+        for _ in 0..self.height.saturating_sub(1) {
             self.term.clear_line()?;
-        } else {
-            self.term.clear_last_lines(self.height)?;
+            self.term.move_cursor_up(1)?;
         }
+        self.term.clear_line()?;
         self.height = 0;
         Ok(())
     }

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -161,7 +161,7 @@ impl<'a> Spinner<'a> {
                 }
                 self.clear()?;
                 let output = self.render()?;
-                self.height = output.lines().count() - 1;
+                self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
                 self.term.write_all(output.as_bytes())?;
                 sleep(self.style.fps);
                 if handle.is_finished() {

--- a/src/test.rs
+++ b/src/test.rs
@@ -9,3 +9,63 @@ fn init() {
 pub fn without_ansi(s: &str) -> Cow<'_, str> {
     console::strip_ansi_codes(s)
 }
+
+/// A `Term` whose output is captured in memory, for driving a widget's
+/// redraw path and replaying the bytes through a vt100 emulator.
+///
+/// `Term::read_write_pair` is `#[cfg(unix)]` in the console crate. CI also
+/// runs on Windows, where there is simply no test seam — the redraw bugs
+/// these cover were reported on Linux/macOS and the fixes are
+/// platform-agnostic, so unix-only coverage is sufficient.
+#[cfg(unix)]
+pub use capture::{capture_term, snapshot};
+
+#[cfg(unix)]
+mod capture {
+    use console::Term;
+    use std::fs::{File, OpenOptions};
+    use std::io::Write;
+    use std::os::fd::{AsRawFd, RawFd};
+    use std::sync::{Arc, Mutex};
+
+    /// `Term::read_write_pair` is bounded by `Write + Debug + AsRawFd + Send
+    /// + 'static`. It only uses the fd for its own `AsRawFd` impl — the
+    /// actual I/O goes through `Write::write_all` — so we can satisfy the
+    /// trait by holding a throwaway `/dev/null` handle and capture bytes
+    /// into a shared `Vec` without any kernel round-trip.
+    #[derive(Debug)]
+    pub struct CaptureWriter {
+        _fd: File,
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.bytes.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl AsRawFd for CaptureWriter {
+        fn as_raw_fd(&self) -> RawFd {
+            self._fd.as_raw_fd()
+        }
+    }
+
+    pub fn capture_term() -> (Term, Arc<Mutex<Vec<u8>>>) {
+        let bytes = Arc::new(Mutex::new(Vec::new()));
+        let writer = CaptureWriter {
+            _fd: OpenOptions::new().write(true).open("/dev/null").unwrap(),
+            bytes: Arc::clone(&bytes),
+        };
+        let reader = File::open("/dev/null").unwrap();
+        (Term::read_write_pair(reader, writer), bytes)
+    }
+
+    pub fn snapshot(buf: &Arc<Mutex<Vec<u8>>>) -> Vec<u8> {
+        buf.lock().unwrap().clone()
+    }
+}


### PR DESCRIPTION
Any prompt whose rendered frame is wider than the terminal duplicates itself on every keypress.

Widgets clear the previous frame with `Term::clear_last_lines(self.height)`, which works in **physical rows**, but `height` was computed as `output.lines().count() - 1` — **logical lines**. A line wider than the terminal wraps into rows the clear never erases, so the next frame draws below the leftovers and the prompt stacks.

Found via https://github.com/jdx/aube/discussions/1107, where a `Select` of `package.json` scripts (labels like `build: tsc -p tsconfig.build.json && rollup -c …`) scrambled on every arrow key. Driving that picker through a pty at 80 columns, two ↓ presses, replayed through a terminal emulator:

```
 0 |Select a script to run
 1 |package.json scripts
 2 |❯ build: tsc -p tsconfig.build.json && rollup -c rollup.config.mjs --environment
 3 |Select a script to run          ← stale
 4 |package.json scripts
 5 |  build: tsc -p tsconfig.build.json && rollup -c rollup.config.mjs --environment
 6 |Select a script to run          ← stale
 7 |package.json scripts
 8 |  build: …
```

The same frames at 200 columns are perfectly clean, which is what pins it on wrapping rather than anything terminal-specific.

## The fix

A shared `height::rendered_height(output, width)` counts the physical rows a frame occupies: for each line, `measure_text_width(line).div_ceil(width)`, so ANSI codes don't inflate the count and a line exactly `width` wide still counts as one row (terminals defer the wrap).

Applied to every widget that redraws via `clear_last_lines`: `Confirm`, `Dialog`, `Input`, `List`, `Select`, `Spinner`.

One subtlety worth flagging: the helper splits on `'\n'` and drops the final segment rather than using `lines()`. What we want is the rows *above* the cursor, and the cursor rests on whatever follows the last newline — the trailing color reset, or nothing. `lines()` swallows a trailing empty segment, so it would lose a row for any widget whose output doesn't end in that reset. `split('\n')` handles both endings identically.

## Not in this PR

`MultiSelect` is untouched. It doesn't use `clear_last_lines` — `reposition_and_write` rewrites line by line and clears each with `clear_line`, which erases one physical row. Making it wrap-aware means more than swapping the count (a shrinking wrapped line leaves a tail row that `clear_line` won't reach), so it deserves its own change rather than a partial one bolted onto this.

## Tests

- Unit tests for `rendered_height`: the trailing-fragment handling, exact-width lines, multi-row wrapping, ANSI-aware measurement, and zero width.
- A `Select` regression test that drives three real redraw cycles through a captured `Term`, replays the bytes through vt100, and asserts the screen holds one copy of the prompt. It fails with logical-line counting (3 copies) and passes with physical rows.
  - The test applies ONLCR (`\n` → `\r\n`) before feeding the emulator, since a real TTY does that and the row arithmetic is meaningless without it.
- The `Term` capture harness moved out of `multiselect.rs` into `test.rs` so both suites share it.
- `Select::run`'s render-and-record step is now a small `draw()` method, so the regression test exercises the same code path instead of a copy of it.

`cargo test --lib` is green (37 passing) and `cargo clippy --all-targets -- -D warnings` is clean.

Verified end to end by building aube against this branch: the picker is stable at 80 columns and at 34, where the wrapping help footer alone used to retrigger the stacking.

*This PR was generated by Claude.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TTY redraw/clear paths across multiple widgets; behavior is well-tested but incorrect row math would cause visible glitches or cursor misplacement.
> 
> **Overview**
> Fixes prompts **duplicating on every keypress** when rendered text is wider than the terminal. Redraw logic used **logical line count** for `clear_last_lines`, but terminals clear **physical rows**, so wrapped lines were left on screen.
> 
> Adds **`height::rendered_height`** (and **`rendered_rows`** for frames without a trailing newline) using terminal width and `measure_text_width` so ANSI and wrapping are counted correctly. **Confirm**, **Dialog**, **Input**, **List**, **Select**, and **Spinner** now record frame height this way; **Input** also computes **`input_line_offset`** in rows for caret placement when titles wrap.
> 
> **Spinner** clears by walking up from the cursor row instead of `clear_last_lines`, since the cursor sits on the last row of the frame. **Select** centralizes redraw in **`draw()`** for tests.
> 
> Adds unit tests for height math, Input offset behavior, a **Select** vt100 regression for stacked frames, and moves the unix **Term** capture harness to **`test.rs`** for reuse. **MultiSelect** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d99347b91fb973ce8e6f32a8905cd4f27a65bd37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->