### PR TITLE
chore: release v2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.4](https://github.com/jdx/demand/compare/v2.0.3...v2.0.4) - 2026-07-25
+
+### Fixed
+
+- clear wrapped lines when redrawing a prompt ([#190](https://github.com/jdx/demand/pull/190))
+
 ## [2.0.3](https://github.com/jdx/demand/compare/v2.0.2...v2.0.3) - 2026-07-03
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demand"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2024"
 description = "A CLI prompt library"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `demand`: 2.0.3 -> 2.0.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.4](https://github.com/jdx/demand/compare/v2.0.3...v2.0.4) - 2026-07-25

### Fixed

- clear wrapped lines when redrawing a prompt ([#190](https://github.com/jdx/demand/pull/190))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only metadata with no source changes in this PR; the shipped fix is a localized terminal redraw behavior change.
> 
> **Overview**
> **Release v2.0.4** bumps the crate version from **2.0.3** to **2.0.4** and documents the release in **CHANGELOG.md**.
> 
> The only user-facing change in this release is a **terminal rendering fix** ([#190](https://github.com/jdx/demand/pull/190)): when a prompt redraws, **wrapped lines from the previous frame are cleared** so leftover rows do not stack and duplicate the UI on each keypress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b87fae183144b01ccfeee363243de47e75ad7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->