### PR TITLE
fix(multiselect): clear wrapped rows when redrawing

### DIFF
--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -67,7 +67,7 @@ pub struct MultiSelect<'a, T> {
     cursor_x: usize,
     cursor_y: usize,
     cursor: usize,
-    last_line_count: usize,
+    height: usize,
     term: Term,
     pages: usize,
     cur_page: usize,
@@ -90,7 +90,7 @@ impl<'a, T> MultiSelect<'a, T> {
             cursor_y: 0,
             err: None,
             cursor: 0,
-            last_line_count: 0,
+            height: 0,
             term: Term::stderr(),
             filter: String::new(),
             filtering: false,
@@ -180,10 +180,7 @@ impl<'a, T> MultiSelect<'a, T> {
         self.min = self.min.min(self.max);
 
         loop {
-            let output = self.render()?;
-            let line_count = output.lines().count();
-
-            self.reposition_and_write(&output, line_count)?;
+            self.redraw()?;
 
             if self.filtering {
                 match self.term.read_key()? {
@@ -662,49 +659,21 @@ impl<'a, T> MultiSelect<'a, T> {
         Ok(std::str::from_utf8(out.as_slice()).unwrap().to_string())
     }
 
-    fn reposition_and_write(&mut self, output: &str, line_count: usize) -> io::Result<()> {
-        // The previous render leaves the cursor at the end of its last line
-        // (no trailing newline), so row `last_line_count - 1` of that render.
-        // Moving up by the full count would land one row above the top.
-        if self.last_line_count > 0 {
-            self.term.move_cursor_up(self.last_line_count - 1)?;
-        }
-
-        self.term.move_cursor_left(usize::MAX)?;
-
-        let mut lines = output.lines().peekable();
-        while let Some(line) = lines.next() {
-            self.term.move_cursor_left(usize::MAX)?;
-            self.term.clear_line()?;
-
-            write!(self.term, "{}", line)?;
-
-            if lines.peek().is_some() {
-                writeln!(self.term)?;
-            }
-        }
-
-        if line_count < self.last_line_count {
-            let extra = self.last_line_count - line_count;
-            for _ in 0..extra {
-                writeln!(self.term)?;
-                self.term.move_cursor_left(usize::MAX)?;
-                self.term.clear_line()?;
-            }
-            // Leave the cursor on the last line of the new render so the
-            // invariant above (cursor at end of row N-1) still holds.
-            self.term.move_cursor_up(extra)?;
-        }
-
-        self.last_line_count = line_count;
+    /// Clear the previous frame, render the next one, and remember its
+    /// physical height. Terminal wrapping can make one logical line occupy
+    /// several rows, so `output.lines().count()` is not sufficient here.
+    fn redraw(&mut self) -> io::Result<()> {
+        self.cleanup()?;
+        let output = self.render()?;
+        self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
+        self.term.write_all(output.as_bytes())?;
         self.term.flush()?;
         Ok(())
     }
 
     fn cleanup(&mut self) -> io::Result<()> {
-        if self.last_line_count > 0 {
-            self.term.clear_last_lines(self.last_line_count)?;
-        }
+        self.term.clear_last_lines(self.height)?;
+        self.height = 0;
         Ok(())
     }
 }
@@ -713,7 +682,7 @@ impl<'a, T> MultiSelect<'a, T> {
 mod tests {
     use crate::test::without_ansi;
     #[cfg(unix)]
-    use crate::test::{capture_term, snapshot};
+    use crate::test::{capture_term, replay, snapshot};
 
     use super::*;
     use indoc::indoc;
@@ -797,10 +766,8 @@ mod tests {
         );
     }
 
-    /// Regression for the off-by-one in `reposition_and_write` (jdx/demand#129):
-    /// a previous version moved the cursor up by `last_line_count` instead of
-    /// `last_line_count - 1`, causing the menu to drift up by one row on every
-    /// keypress in `mise up -i` and any other multi-iteration redraw.
+    /// Regression for the off-by-one in the old line-by-line repositioning
+    /// code (jdx/demand#129), which made the menu drift up on every keypress.
     ///
     /// Drives the redraw path through a `Term::read_write_pair` whose writer is
     /// a `SharedBuf`, replays the captured bytes through a vt100 emulator, and
@@ -808,7 +775,7 @@ mod tests {
     /// origin doesn't drift).
     #[cfg(unix)]
     #[test]
-    fn reposition_does_not_drift_upward() {
+    fn redraw_does_not_drift_upward() {
         let (term, buf) = capture_term();
         let mut ms = MultiSelect::new("Toppings")
             .option(DemandOption::new("Lettuce"))
@@ -826,12 +793,10 @@ mod tests {
         let mut cursor_rows = Vec::new();
         for _ in 0..6 {
             let before = snapshot(&buf).len();
-            let output = ms.render().unwrap();
-            let line_count = output.lines().count();
-            ms.reposition_and_write(&output, line_count).unwrap();
+            ms.redraw().unwrap();
 
             let new_bytes = snapshot(&buf)[before..].to_vec();
-            parser.process(&new_bytes);
+            replay(&mut parser, &new_bytes);
             cursor_rows.push(parser.screen().cursor_position().0);
 
             // Move the in-menu cursor so the renders aren't byte-identical and
@@ -839,7 +804,7 @@ mod tests {
             ms.handle_down().unwrap();
         }
 
-        // After iter 1 the vt100 cursor settles at row (start + line_count - 1).
+        // After iter 1 the vt100 cursor settles at the end of the frame.
         // With the bug, every subsequent iter pulls it up by another row; with
         // the fix it stays put.
         let first = cursor_rows[0];
@@ -851,16 +816,14 @@ mod tests {
         }
     }
 
-    /// Companion to `reposition_does_not_drift_upward`: when the rendered
-    /// output shrinks, the new last-line-count must keep the same "cursor at
-    /// end of last row" invariant so the next iteration's `move_cursor_up`
-    /// still lands on row 0 of the new render.
+    /// When the rendered output shrinks, redraw must clear the rows that are
+    /// no longer occupied and leave the cursor at the end of the new frame.
     #[cfg(unix)]
     #[test]
-    fn reposition_handles_shrinking_render() {
+    fn redraw_clears_rows_when_wrapped_frame_shrinks() {
         let (term, buf) = capture_term();
         let mut ms = MultiSelect::new("T")
-            .option(DemandOption::new("a"))
+            .option(DemandOption::new("long").label(&"x".repeat(140)))
             .option(DemandOption::new("b"))
             .option(DemandOption::new("c"));
         ms.term = term;
@@ -870,38 +833,61 @@ mod tests {
 
         // First render with all 3 options.
         let before = snapshot(&buf).len();
-        let output = ms.render().unwrap();
-        let line_count_full = output.lines().count();
-        ms.reposition_and_write(&output, line_count_full).unwrap();
-        parser.process(&snapshot(&buf)[before..]);
+        ms.redraw().unwrap();
+        replay(&mut parser, &snapshot(&buf)[before..]);
         let row_after_full = parser.screen().cursor_position().0;
 
-        // Drop two options, forcing the next render to shrink.
+        // Remove the wrapped option and one short option, forcing the next
+        // render to shrink by both logical and physical rows.
+        ms.options.remove(0);
         ms.options.truncate(1);
 
         let before = snapshot(&buf).len();
-        let output = ms.render().unwrap();
-        let line_count = output.lines().count();
-        ms.reposition_and_write(&output, line_count).unwrap();
-        parser.process(&snapshot(&buf)[before..]);
+        ms.redraw().unwrap();
+        replay(&mut parser, &snapshot(&buf)[before..]);
         let row_after_short = parser.screen().cursor_position().0;
 
-        assert!(line_count < line_count_full, "render must actually shrink");
-        // Cursor should land on the last row of the shorter render — i.e. it
-        // should have moved up by the difference, not stayed at the old depth.
-        assert_eq!(
-            row_after_short,
-            row_after_full - (line_count_full - line_count) as u16,
-            "cursor didn't reposition correctly after shrink"
-        );
+        assert!(row_after_short < row_after_full);
+        assert!(!parser.screen().contents().contains("xxxxxxxx"));
 
         // The third render must again be stable — a fresh redraw on top of
         // the shrunken state without further drift.
         let before = snapshot(&buf).len();
-        let output = ms.render().unwrap();
-        let line_count = output.lines().count();
-        ms.reposition_and_write(&output, line_count).unwrap();
-        parser.process(&snapshot(&buf)[before..]);
+        ms.redraw().unwrap();
+        replay(&mut parser, &snapshot(&buf)[before..]);
         assert_eq!(parser.screen().cursor_position().0, row_after_short);
+    }
+
+    /// Regression for jdx/mise#11326: a wrapped option used to make each
+    /// redraw start below stale physical rows, stacking another copy of the
+    /// prompt on every keypress.
+    #[cfg(unix)]
+    #[test]
+    fn wrapped_option_does_not_stack_copies_of_the_frame() {
+        let (term, buf) = capture_term();
+        let mut ms = MultiSelect::new("mise upgrade")
+            .option(DemandOption::new("long").label(&"x".repeat(140)))
+            .option(DemandOption::new("short"));
+        ms.term = term;
+        let width = ms.term.size().1 as usize;
+        assert!(width < 140, "test needs a label wider than the terminal");
+
+        let mut parser = vt100::Parser::new(40, width as u16, 0);
+        parser.process(&b"\n".repeat(20));
+
+        for _ in 0..3 {
+            let before = snapshot(&buf).len();
+            ms.redraw().unwrap();
+
+            replay(&mut parser, &snapshot(&buf)[before..]);
+            ms.handle_down().unwrap();
+        }
+
+        let screen = parser.screen().contents();
+        assert_eq!(
+            screen.matches("mise upgrade").count(),
+            1,
+            "prompt drawn more than once:\n{screen}"
+        );
     }
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -505,7 +505,7 @@ impl<'a, T> Select<'a, T> {
 mod tests {
     use crate::test::without_ansi;
     #[cfg(unix)]
-    use crate::test::{capture_term, snapshot};
+    use crate::test::{capture_term, replay, snapshot};
 
     use super::*;
     use indoc::indoc;
@@ -609,17 +609,7 @@ mod tests {
         }
 
         let mut parser = vt100::Parser::new(24, width as u16, 0);
-        // A real terminal maps the widget's `\n` to CR+LF (ONLCR); the
-        // emulator doesn't, and without it the cursor keeps its column and
-        // the row math is meaningless.
-        let mut bytes = Vec::new();
-        for b in snapshot(&buf) {
-            if b == b'\n' {
-                bytes.push(b'\r');
-            }
-            bytes.push(b);
-        }
-        parser.process(&bytes);
+        replay(&mut parser, &snapshot(&buf));
         let screen = parser.screen().contents();
         assert_eq!(
             screen.matches("Pick a script").count(),

--- a/src/test.rs
+++ b/src/test.rs
@@ -18,7 +18,7 @@ pub fn without_ansi(s: &str) -> Cow<'_, str> {
 /// these cover were reported on Linux/macOS and the fixes are
 /// platform-agnostic, so unix-only coverage is sufficient.
 #[cfg(unix)]
-pub use capture::{capture_term, snapshot};
+pub use capture::{capture_term, replay, snapshot};
 
 #[cfg(unix)]
 mod capture {
@@ -67,5 +67,20 @@ mod capture {
 
     pub fn snapshot(buf: &Arc<Mutex<Vec<u8>>>) -> Vec<u8> {
         buf.lock().unwrap().clone()
+    }
+
+    /// Replay captured terminal output with the newline translation a real
+    /// Unix TTY performs. The emulator does not apply ONLCR itself, so feeding
+    /// raw `\n` bytes would leave the cursor column unchanged and make redraw
+    /// assertions model a pipe rather than a terminal.
+    pub fn replay(parser: &mut vt100::Parser, output: &[u8]) {
+        let mut tty_output = Vec::with_capacity(output.len());
+        for &byte in output {
+            if byte == b'\n' {
+                tty_output.push(b'\r');
+            }
+            tty_output.push(byte);
+        }
+        parser.process(&tty_output);
     }
 }


### PR DESCRIPTION
## Summary

- replace `MultiSelect`'s logical-line repositioning with physical-row-aware clear-and-redraw behavior
- reuse the shared `rendered_height` calculation introduced for the other prompt widgets
- add VT100 regression coverage for wrapped options, shrinking wrapped frames, and the existing no-drift behavior
- centralize Unix TTY newline replay so terminal tests model ONLCR consistently

## Root cause

`MultiSelect` counted `output.lines()` and repositioned/cleared one row per logical line. When an option or help footer exceeded the terminal width, it occupied multiple physical rows. Subsequent keypresses left those extra rows behind and drew the next frame below them, stacking repeated copies of the prompt.

This is the `MultiSelect` counterpart to #190, which deliberately left this widget for a follow-up because its line-by-line redraw path needed separate handling. It was reported through [jdx/mise discussion #11326](https://github.com/jdx/mise/discussions/11326) in `mise up --interactive`.

## User impact

Interactive multi-select prompts remain stable in narrow terminals and with long option labels. Filtering or otherwise shrinking the frame also clears rows previously occupied by wrapped content.

## Validation

- `cargo fmt --check`
- `cargo test --lib` (41 passed)
- `cargo clippy --all-targets -- -D warnings`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terminal UI redraw logic only; behavior aligns with existing Select/height helpers and is covered by vt100 regression tests.
> 
> **Overview**
> **MultiSelect** no longer redraws by moving the cursor up one row per logical line. Each keypress now **clears the previous frame using physical terminal height** (via shared `rendered_height`), then writes the new output—matching **Select** and fixing stacked duplicate prompts when options wrap in narrow terminals.
> 
> The old `reposition_and_write` path and `last_line_count` tracking are removed in favor of `redraw` + `height`. **Unix terminal tests** use a shared `replay` helper so vt100 replay applies **ONLCR** (`\n` → `\r\n`), and regression coverage adds wrapped-option and shrinking-frame cases for **MultiSelect**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c0848b9b1001d15217c49d0947cc867d1286ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->