### PR TITLE
fix: synchronize in-place prompt redraws

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,8 @@ indoc = "2"
 insta = "1"
 vt100 = "0.16"
 
+[target.'cfg(unix)'.dev-dependencies]
+portable-pty = "0.9"
+
 [profile.dev]
 debug = 1

--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -198,11 +198,14 @@ impl<'a> Confirm<'a> {
         self.term.clear_line()?;
         self.term.hide_cursor()?;
         loop {
-            self.clear()?;
-            let output = self.render()?;
-            self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
-            self.term.write_all(output.as_bytes())?;
-            self.term.flush()?;
+            let term = self.term.clone();
+            crate::synchronized_output::run(&term, || {
+                self.clear()?;
+                let output = self.render()?;
+                self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
+                self.term.write_all(output.as_bytes())?;
+                self.term.flush()
+            })?;
             match self.term.read_key()? {
                 Key::ArrowLeft | Key::Char('h') => self.handle_left(),
                 Key::ArrowRight | Key::Char('l') => self.handle_right(),
@@ -232,11 +235,14 @@ impl<'a> Confirm<'a> {
     }
 
     fn handle_submit(mut self) -> io::Result<bool> {
-        self.term.clear_to_end_of_screen()?;
-        self.clear()?;
-        self.term.show_cursor()?;
-        let output = self.render_success()?;
-        self.term.write_all(output.as_bytes())?;
+        let term = self.term.clone();
+        crate::synchronized_output::run(&term, || {
+            self.term.clear_to_end_of_screen()?;
+            self.clear()?;
+            self.term.show_cursor()?;
+            let output = self.render_success()?;
+            self.term.write_all(output.as_bytes())
+        })?;
         Ok(self.selected)
     }
 

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -143,11 +143,14 @@ impl<'a> Dialog<'a> {
 
         self.term.hide_cursor()?;
         loop {
-            self.clear()?;
-            let output = self.render()?;
-            self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
-            self.term.write_all(output.as_bytes())?;
-            self.term.flush()?;
+            let term = self.term.clone();
+            crate::synchronized_output::run(&term, || {
+                self.clear()?;
+                let output = self.render()?;
+                self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
+                self.term.write_all(output.as_bytes())?;
+                self.term.flush()
+            })?;
             match self.term.read_key()? {
                 Key::ArrowLeft | Key::Char('h') => self.handle_left(),
                 Key::ArrowRight | Key::Char('l') => self.handle_right(),
@@ -172,10 +175,13 @@ impl<'a> Dialog<'a> {
     }
 
     fn handle_submit(mut self) -> io::Result<String> {
-        self.clear()?;
-        self.term.show_cursor()?;
-        let output = self.render_success()?;
-        self.term.write_all(output.as_bytes())?;
+        let term = self.term.clone();
+        crate::synchronized_output::run(&term, || {
+            self.clear()?;
+            self.term.show_cursor()?;
+            let output = self.render_success()?;
+            self.term.write_all(output.as_bytes())
+        })?;
         let result = if !self.buttons.is_empty() {
             self.buttons[self.selected_button_idx].label.clone()
         } else {

--- a/src/input.rs
+++ b/src/input.rs
@@ -374,13 +374,16 @@ impl<'a> Input<'a> {
         self.update_suggestions()?;
 
         loop {
-            self.clear()?;
-            let output = self.render()?;
+            let term = self.term.clone();
+            crate::synchronized_output::run(&term, || {
+                self.clear()?;
+                let output = self.render()?;
 
-            self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
-            self.term.write_all(output.as_bytes())?;
-            self.term.flush()?;
-            self.set_cursor()?;
+                self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
+                self.term.write_all(output.as_bytes())?;
+                self.term.flush()?;
+                self.set_cursor()
+            })?;
 
             let key = self.term.read_key()?;
             match key {
@@ -565,9 +568,12 @@ impl<'a> Input<'a> {
     }
 
     fn handle_submit(mut self) -> io::Result<String> {
-        self.clear()?;
-        let output = self.render_success()?;
-        self.term.write_all(output.as_bytes())?;
+        let term = self.term.clone();
+        crate::synchronized_output::run(&term, || {
+            self.clear()?;
+            let output = self.render_success()?;
+            self.term.write_all(output.as_bytes())
+        })?;
         Ok(self.input)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ mod multiselect;
 mod option;
 mod select;
 mod spinner;
+mod synchronized_output;
 mod theme;
 mod tty;
 mod wizard;

--- a/src/list.rs
+++ b/src/list.rs
@@ -128,11 +128,15 @@ impl<'a> List<'a> {
         let ctrlc_handle = ctrlc::show_cursor_after_ctrlc(&self.term)?;
 
         loop {
-            self.clear()?;
-            let output = self.render()?;
-            self.term.write_all(output.as_bytes())?;
-            self.term.flush()?;
-            self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
+            let term = self.term.clone();
+            crate::synchronized_output::run(&term, || {
+                self.clear()?;
+                let output = self.render()?;
+                self.term.write_all(output.as_bytes())?;
+                self.term.flush()?;
+                self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
+                Ok(())
+            })?;
             if self.filtering {
                 match self.term.read_key()? {
                     Key::Enter => self.handle_stop_filtering(true)?,
@@ -155,11 +159,14 @@ impl<'a> List<'a> {
                         return Err(io::Error::new(io::ErrorKind::Interrupted, "user cancelled"));
                     }
                     Key::Enter => {
-                        self.clear()?;
-                        self.term.show_cursor()?;
                         ctrlc_handle.close();
-                        let output = self.render_success()?;
-                        self.term.write_all(output.as_bytes())?;
+                        let term = self.term.clone();
+                        crate::synchronized_output::run(&term, || {
+                            self.clear()?;
+                            self.term.show_cursor()?;
+                            let output = self.render_success()?;
+                            self.term.write_all(output.as_bytes())
+                        })?;
                         return Ok(());
                     }
                     _ => {}

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -180,7 +180,8 @@ impl<'a, T> MultiSelect<'a, T> {
         self.min = self.min.min(self.max);
 
         loop {
-            self.redraw()?;
+            let term = self.term.clone();
+            crate::synchronized_output::run(&term, || self.redraw())?;
 
             if self.filtering {
                 match self.term.read_key()? {
@@ -190,19 +191,8 @@ impl<'a, T> MultiSelect<'a, T> {
                     Key::ArrowRight => self.handle_right()?,
                     Key::Enter => {
                         if let Some(selected) = self.try_confirm() {
-                            self.cleanup()?;
-                            self.term.show_cursor()?;
                             ctrlc_handle.close();
-                            let output = self.render_success(&selected)?;
-                            self.term.write_all(output.as_bytes())?;
-                            let selected = self
-                                .options
-                                .into_iter()
-                                .filter(|o| o.selected)
-                                .map(|o| o.item)
-                                .collect::<Vec<_>>();
-                            self.term.clear_to_end_of_screen()?;
-                            return Ok(selected);
+                            return self.finish(selected);
                         }
                     }
                     Key::Escape => self.handle_stop_filtering(false)?,
@@ -235,25 +225,31 @@ impl<'a, T> MultiSelect<'a, T> {
                     }
                     Key::Enter => {
                         if let Some(selected) = self.try_confirm() {
-                            self.cleanup()?;
-                            self.term.show_cursor()?;
                             ctrlc_handle.close();
-                            let output = self.render_success(&selected)?;
-                            self.term.write_all(output.as_bytes())?;
-                            let selected = self
-                                .options
-                                .into_iter()
-                                .filter(|o| o.selected)
-                                .map(|o| o.item)
-                                .collect::<Vec<_>>();
-                            self.term.clear_to_end_of_screen()?;
-                            return Ok(selected);
+                            return self.finish(selected);
                         }
                     }
                     _ => {}
                 }
             }
         }
+    }
+
+    fn finish(mut self, selected_labels: Vec<String>) -> io::Result<Vec<T>> {
+        let output = self.render_success(&selected_labels)?;
+        let term = self.term.clone();
+        crate::synchronized_output::run(&term, || {
+            self.cleanup()?;
+            self.term.show_cursor()?;
+            self.term.write_all(output.as_bytes())?;
+            self.term.clear_to_end_of_screen()
+        })?;
+        Ok(self
+            .options
+            .into_iter()
+            .filter(|option| option.selected)
+            .map(|option| option.item)
+            .collect())
     }
 
     fn filtered_options(&self) -> Vec<&DemandOption<T>> {

--- a/src/select.rs
+++ b/src/select.rs
@@ -138,18 +138,24 @@ impl<'a, T> Select<'a, T> {
         let ctrlc_handle = ctrlc::show_cursor_after_ctrlc(&self.term)?;
 
         loop {
-            self.clear()?;
-            self.draw()?;
-            self.term.hide_cursor()?;
+            let term = self.term.clone();
+            crate::synchronized_output::run(&term, || {
+                self.clear()?;
+                self.draw()?;
+                self.term.hide_cursor()
+            })?;
             let enter = |mut select: Select<T>| {
-                select.clear()?;
-                select.term.show_cursor()?;
                 let id = select.visible_options().get(select.cursor_y).unwrap().id;
                 let selected = select.options.iter().find(|o| o.id == id).unwrap();
                 let output = select.render_success(&selected.label)?;
+                let term = select.term.clone();
+                crate::synchronized_output::run(&term, || {
+                    select.clear()?;
+                    select.term.show_cursor()?;
+                    select.term.write_all(output.as_bytes())?;
+                    select.term.clear_to_end_of_screen()
+                })?;
                 let selected = select.options.into_iter().find(|o| o.id == id).unwrap();
-                select.term.write_all(output.as_bytes())?;
-                select.term.clear_to_end_of_screen()?;
                 Ok::<T, io::Error>(selected.item)
             };
 

--- a/src/spinner.rs
+++ b/src/spinner.rs
@@ -159,13 +159,17 @@ impl<'a> Spinner<'a> {
                         break;
                     }
                 }
-                self.clear()?;
-                let output = self.render()?;
-                // `rendered_rows`, not `rendered_height`: the spinner frame
-                // has no trailing newline, so the cursor sits on its last
-                // row and that row counts.
-                self.height = crate::height::rendered_rows(&output, self.term.size().1 as usize);
-                self.term.write_all(output.as_bytes())?;
+                let term = self.term.clone();
+                crate::synchronized_output::run(&term, || {
+                    self.clear()?;
+                    let output = self.render()?;
+                    // `rendered_rows`, not `rendered_height`: the spinner frame
+                    // has no trailing newline, so the cursor sits on its last
+                    // row and that row counts.
+                    self.height =
+                        crate::height::rendered_rows(&output, self.term.size().1 as usize);
+                    self.term.write_all(output.as_bytes())
+                })?;
                 sleep(self.style.fps);
                 if handle.is_finished() {
                     self.clear()?;

--- a/src/synchronized_output.rs
+++ b/src/synchronized_output.rs
@@ -1,0 +1,70 @@
+use std::io;
+
+use console::Term;
+
+const BEGIN: &str = "\x1b[?2026h";
+const END: &str = "\x1b[?2026l";
+
+/// Run an in-place terminal update inside DEC private mode 2026.
+///
+/// Supporting terminals buffer the enclosed cursor movement, clearing, and
+/// drawing, then present it as one frame. Terminals that do not implement the
+/// mode ignore the unknown private-mode sequences.
+pub(crate) fn run<T>(term: &Term, update: impl FnOnce() -> io::Result<T>) -> io::Result<T> {
+    term.write_str(BEGIN)?;
+    let guard = Guard {
+        term: term.clone(),
+        finished: false,
+    };
+    let result = update();
+    let end_result = guard.finish();
+    match result {
+        Ok(value) => end_result.map(|()| value),
+        Err(err) => Err(err),
+    }
+}
+
+struct Guard {
+    term: Term,
+    finished: bool,
+}
+
+impl Guard {
+    fn finish(mut self) -> io::Result<()> {
+        self.finished = true;
+        self.term.write_str(END)
+    }
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        if !self.finished {
+            let _ = self.term.write_str(END);
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::test::{capture_term, snapshot};
+
+    #[test]
+    fn brackets_an_update() {
+        let (term, bytes) = capture_term();
+
+        run(&term, || term.write_str("frame")).unwrap();
+
+        assert_eq!(snapshot(&bytes), b"\x1b[?2026hframe\x1b[?2026l");
+    }
+
+    #[test]
+    fn closes_an_update_after_an_error() {
+        let (term, bytes) = capture_term();
+
+        let result = run::<()>(&term, || Err(io::Error::other("redraw failed")));
+
+        assert_eq!(result.unwrap_err().to_string(), "redraw failed");
+        assert_eq!(snapshot(&bytes), b"\x1b[?2026h\x1b[?2026l");
+    }
+}

--- a/tests/synchronized_output.rs
+++ b/tests/synchronized_output.rs
@@ -1,0 +1,134 @@
+//! Exercises a real interactive redraw under a pseudo-terminal and verifies
+//! that terminals never receive a presentable partial frame.
+#![cfg(unix)]
+
+use std::io::{Read, Write};
+
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+
+const BEGIN: &[u8] = b"\x1b[?2026h";
+
+#[test]
+fn synchronized_output_child_scenario() {
+    if std::env::var_os("DEMAND_PTY_SCENARIO").is_none() {
+        return;
+    }
+
+    use demand::{DemandOption, MultiSelect};
+
+    MultiSelect::new("Choose")
+        .filterable(true)
+        .option(DemandOption::new("one"))
+        .option(DemandOption::new("two"))
+        .run()
+        .expect("run multiselect");
+
+    std::process::exit(0);
+}
+
+#[test]
+fn every_multiselect_redraw_is_synchronized() {
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("openpty");
+
+    let mut cmd = CommandBuilder::new(std::env::current_exe().expect("current_exe"));
+    cmd.args([
+        "--exact",
+        "synchronized_output_child_scenario",
+        "--nocapture",
+    ]);
+    cmd.env("DEMAND_PTY_SCENARIO", "1");
+
+    let mut child = pair.slave.spawn_command(cmd).expect("spawn child");
+    drop(pair.slave);
+
+    let mut writer = pair.master.take_writer().expect("take writer");
+    // Trigger a second frame, select the highlighted item, and submit.
+    writer.write_all(b"\x1b[B \r").expect("write input");
+    writer.flush().expect("flush input");
+    drop(writer);
+
+    let mut reader = pair.master.try_clone_reader().expect("clone reader");
+    let mut bytes = Vec::new();
+    reader.read_to_end(&mut bytes).expect("read pty");
+    child.wait().expect("wait child");
+    drop(pair.master);
+
+    assert!(
+        contains(&bytes, BEGIN),
+        "scenario emitted no synchronized-update sequences"
+    );
+
+    let mut open = false;
+    let mut frames = 0;
+    for operation in escapes(&bytes) {
+        match operation {
+            Escape::Begin => {
+                assert!(!open, "nested synchronized update");
+                open = true;
+                frames += 1;
+            }
+            Escape::End => {
+                assert!(open, "synchronized-update end without a begin");
+                open = false;
+            }
+            Escape::Erase => {
+                assert!(
+                    open,
+                    "in-place erase outside a synchronized update: {}",
+                    String::from_utf8_lossy(&bytes).escape_debug()
+                );
+            }
+        }
+    }
+    assert!(!open, "stream ended with a synchronized update open");
+    assert!(frames >= 2, "scenario did not exercise a redraw");
+}
+
+enum Escape {
+    Begin,
+    End,
+    Erase,
+}
+
+fn escapes(bytes: &[u8]) -> Vec<Escape> {
+    let mut output = Vec::new();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != 0x1b || bytes.get(index + 1) != Some(&b'[') {
+            index += 1;
+            continue;
+        }
+
+        let params_start = index + 2;
+        let mut end = params_start;
+        while end < bytes.len() && !(0x40..=0x7e).contains(&bytes[end]) {
+            end += 1;
+        }
+        if end >= bytes.len() {
+            break;
+        }
+
+        let params = &bytes[params_start..end];
+        match bytes[end] {
+            b'h' if params == b"?2026" => output.push(Escape::Begin),
+            b'l' if params == b"?2026" => output.push(Escape::End),
+            b'A' | b'J' | b'K' => output.push(Escape::Erase),
+            _ => {}
+        }
+        index = end + 1;
+    }
+    output
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}


### PR DESCRIPTION
## Summary

- bracket interactive prompt redraws in DEC private mode 2026 synchronized updates
- cover `Confirm`, `Dialog`, `Input`, `List`, `Select`, `MultiSelect`, and `Spinner`
- synchronize both ongoing redraws and final clear-and-success transitions
- add an error-safe guard plus a Unix PTY integration test that inspects the real interactive byte stream

## Problem

Demand redraws prompts through several unbuffered terminal operations: clear or reposition the previous frame, write the replacement, move the cursor, and sometimes clear the remaining screen. Fast-rendering terminals can present between those operations, briefly showing a blank or partially drawn prompt.

This is the same class of flicker fixed in [jdx/clx#101](https://github.com/jdx/clx/pull/101). It is separate from the physical-row accounting bug addressed by #192: synchronized output prevents torn presentation, while correct row accounting prevents persistent stale rows.

## Fix

Each in-place update is enclosed by `ESC[?2026h` and `ESC[?2026l`. Terminals supporting synchronized output buffer the enclosed operations and present them as one frame. Terminals without support ignore the unknown private mode.

The helper always emits the closing sequence after an update error and uses a drop guard to close the mode during unwinding.

## Testing

The Unix-only PTY integration test drives a real `MultiSelect` session and checks that every cursor-up or erase operation occurs inside a balanced synchronized update. It caught an initial gap where normal redraws were bracketed but the final submission transition was not.

Validated after rebasing onto the merged #192 with:

- `cargo fmt --check`
- `cargo test --lib --tests` (43 unit tests and 16 integration tests passed)
- `cargo clippy --all-targets -- -D warnings`

`cargo test` doctests were not used because the existing interactive `List` doctest blocks waiting for terminal input; library and integration targets are clean.

*This PR was generated by an AI coding assistant.*