### PR TITLE
chore: release v2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.0.5](https://github.com/jdx/demand/compare/v2.0.4...v2.0.5) - 2026-07-26
+
+### Fixed
+
+- adapt selector layout after terminal resize ([#195](https://github.com/jdx/demand/pull/195))
+- synchronize in-place prompt redraws ([#193](https://github.com/jdx/demand/pull/193))
+- *(multiselect)* clear wrapped rows when redrawing ([#192](https://github.com/jdx/demand/pull/192))
+
+### Other
+
+- *(ci)* add cargo semver checks ([#196](https://github.com/jdx/demand/pull/196))
+
 ## [2.0.4](https://github.com/jdx/demand/compare/v2.0.3...v2.0.4) - 2026-07-25
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demand"
-version = "2.0.4"
+version = "2.0.5"
 edition = "2024"
 description = "A CLI prompt library"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `demand`: 2.0.4 -> 2.0.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.5](https://github.com/jdx/demand/compare/v2.0.4...v2.0.5) - 2026-07-26

### Fixed

- adapt selector layout after terminal resize ([#195](https://github.com/jdx/demand/pull/195))
- synchronize in-place prompt redraws ([#193](https://github.com/jdx/demand/pull/193))
- *(multiselect)* clear wrapped rows when redrawing ([#192](https://github.com/jdx/demand/pull/192))

### Other

- *(ci)* add cargo semver checks ([#196](https://github.com/jdx/demand/pull/196))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release with no library code changes in the diff.
> 
> **Overview**
> **Release v2.0.5** bumps the `demand` crate from **2.0.4** to **2.0.5** in `Cargo.toml` and adds the matching **CHANGELOG** section for 2026-07-26.
> 
> The changelog records bug fixes already landed elsewhere: terminal resize handling for selectors, synchronized in-place prompt redraws, multiselect wrapped-row cleanup on redraw, plus CI semver checks. This PR does not include those implementation changes—only packaging and release notes (release-plz).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5c8f615acd3d9225ad1c59288307e87e5915d48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->