### PR TITLE
fix: adapt selector layout after terminal resize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ itertools = "0.15"
 signal-hook = "0.4"
 termcolor = "1"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 ctor = "1"
 indoc = "2"

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,12 +2,6 @@ use std::io;
 
 use console::{Key, Term};
 
-pub(crate) enum Event {
-    Key(Key),
-    #[cfg(unix)]
-    Resize,
-}
-
 pub(crate) struct EventReader {
     #[cfg(unix)]
     resize: unix::ResizeListener,
@@ -22,13 +16,16 @@ impl EventReader {
     }
 
     #[cfg(unix)]
-    pub(crate) fn read(&mut self, term: &Term) -> io::Result<Event> {
-        self.resize.read(term)
+    pub(crate) fn read_key(&mut self, term: &Term) -> io::Result<Option<Key>> {
+        self.resize.read(term).map(|event| match event {
+            unix::Event::Key(key) => Some(key),
+            unix::Event::Resize => None,
+        })
     }
 
     #[cfg(not(unix))]
-    pub(crate) fn read(&mut self, term: &Term) -> io::Result<Event> {
-        term.read_key().map(Event::Key)
+    pub(crate) fn read_key(&mut self, term: &Term) -> io::Result<Option<Key>> {
+        term.read_key().map(Some)
     }
 }
 
@@ -43,7 +40,10 @@ mod unix {
     use console::Term;
     use signal_hook::{SigId, consts::SIGWINCH, low_level};
 
-    use super::Event;
+    pub(super) enum Event {
+        Key(console::Key),
+        Resize,
+    }
 
     pub(super) struct ResizeListener {
         input: Option<File>,

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,157 @@
+use std::io;
+
+use console::{Key, Term};
+
+pub(crate) enum Event {
+    Key(Key),
+    #[cfg(unix)]
+    Resize,
+}
+
+pub(crate) struct EventReader {
+    #[cfg(unix)]
+    resize: unix::ResizeListener,
+}
+
+impl EventReader {
+    pub(crate) fn new() -> io::Result<Self> {
+        Ok(Self {
+            #[cfg(unix)]
+            resize: unix::ResizeListener::new()?,
+        })
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn read(&mut self, term: &Term) -> io::Result<Event> {
+        self.resize.read(term)
+    }
+
+    #[cfg(not(unix))]
+    pub(crate) fn read(&mut self, term: &Term) -> io::Result<Event> {
+        term.read_key().map(Event::Key)
+    }
+}
+
+#[cfg(unix)]
+mod unix {
+    use std::fs::{File, OpenOptions};
+    use std::io::{self, Read};
+    use std::mem;
+    use std::os::fd::{AsRawFd, RawFd};
+    use std::os::unix::net::UnixStream;
+
+    use console::Term;
+    use signal_hook::{SigId, consts::SIGWINCH, low_level};
+
+    use super::Event;
+
+    pub(super) struct ResizeListener {
+        input: Option<File>,
+        read: UnixStream,
+        signal_id: SigId,
+    }
+
+    impl ResizeListener {
+        pub(super) fn new() -> io::Result<Self> {
+            let input = if unsafe { libc::isatty(libc::STDIN_FILENO) } == 1 {
+                None
+            } else {
+                Some(OpenOptions::new().read(true).write(true).open("/dev/tty")?)
+            };
+            let (read, write) = UnixStream::pair()?;
+            read.set_nonblocking(true)?;
+            let signal_id = signal_hook::low_level::pipe::register(SIGWINCH, write)?;
+            Ok(Self {
+                input,
+                read,
+                signal_id,
+            })
+        }
+
+        pub(super) fn read(&mut self, term: &Term) -> io::Result<Event> {
+            let input = self
+                .input
+                .as_ref()
+                .map(AsRawFd::as_raw_fd)
+                .unwrap_or(libc::STDIN_FILENO);
+            let resize = self.read.as_raw_fd();
+            let _raw_mode = RawMode::new(input)?;
+
+            loop {
+                let mut read_fds = unsafe { mem::zeroed::<libc::fd_set>() };
+                unsafe {
+                    libc::FD_ZERO(&mut read_fds);
+                    libc::FD_SET(input, &mut read_fds);
+                    libc::FD_SET(resize, &mut read_fds);
+                }
+
+                let result = unsafe {
+                    libc::select(
+                        input.max(resize) + 1,
+                        &mut read_fds,
+                        std::ptr::null_mut(),
+                        std::ptr::null_mut(),
+                        std::ptr::null_mut(),
+                    )
+                };
+                if result < 0 {
+                    let err = io::Error::last_os_error();
+                    if err.kind() == io::ErrorKind::Interrupted {
+                        continue;
+                    }
+                    return Err(err);
+                }
+
+                if unsafe { libc::FD_ISSET(resize, &read_fds) } {
+                    self.drain();
+                    return Ok(Event::Resize);
+                }
+                if unsafe { libc::FD_ISSET(input, &read_fds) } {
+                    return term.read_key().map(Event::Key);
+                }
+            }
+        }
+
+        fn drain(&mut self) {
+            let mut bytes = [0; 64];
+            while matches!(self.read.read(&mut bytes), Ok(n) if n > 0) {}
+        }
+    }
+
+    impl Drop for ResizeListener {
+        fn drop(&mut self) {
+            low_level::unregister(self.signal_id);
+        }
+    }
+
+    struct RawMode {
+        fd: RawFd,
+        original: libc::termios,
+    }
+
+    impl RawMode {
+        fn new(fd: RawFd) -> io::Result<Self> {
+            let mut original = unsafe { mem::zeroed::<libc::termios>() };
+            if unsafe { libc::tcgetattr(fd, &mut original) } != 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            let mut raw = original;
+            unsafe { libc::cfmakeraw(&mut raw) };
+            raw.c_oflag = original.c_oflag;
+            if unsafe { libc::tcsetattr(fd, libc::TCSADRAIN, &raw) } != 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(Self { fd, original })
+        }
+    }
+
+    impl Drop for RawMode {
+        fn drop(&mut self) {
+            unsafe {
+                libc::tcsetattr(self.fd, libc::TCSADRAIN, &self.original);
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod confirm;
 #[cfg_attr(any(windows), path = "ctrlc_stub.rs")]
 mod ctrlc;
 mod dialog;
+mod event;
 mod height;
 mod input;
 mod list;

--- a/src/list.rs
+++ b/src/list.rs
@@ -126,6 +126,7 @@ impl<'a> List<'a> {
     /// an error of type `io::ErrorKind::Interrupted` is returned.
     pub fn run(mut self) -> Result<(), io::Error> {
         let ctrlc_handle = ctrlc::show_cursor_after_ctrlc(&self.term)?;
+        let mut events = crate::event::EventReader::new()?;
 
         loop {
             self.refresh_layout();
@@ -138,8 +139,13 @@ impl<'a> List<'a> {
                 self.last_frame = output;
                 Ok(())
             })?;
+            let key = match events.read(&self.term)? {
+                crate::event::Event::Key(key) => key,
+                #[cfg(unix)]
+                crate::event::Event::Resize => continue,
+            };
             if self.filtering {
-                match self.term.read_key()? {
+                match key {
                     Key::Enter => self.handle_stop_filtering(true)?,
                     Key::Escape => self.handle_stop_filtering(false)?,
                     Key::Backspace => self.handle_filter_backspace()?,
@@ -148,7 +154,7 @@ impl<'a> List<'a> {
                 }
             } else {
                 self.term.hide_cursor()?;
-                match self.term.read_key()? {
+                match key {
                     Key::ArrowUp | Key::Char('k') => self.handle_up(),
                     Key::ArrowDown | Key::Char('j') => self.handle_down()?,
                     Key::ArrowLeft | Key::Char('h') => self.handle_left()?,

--- a/src/list.rs
+++ b/src/list.rs
@@ -53,7 +53,7 @@ pub struct List<'a> {
     filterable: bool,
     filter: String,
     cur_page: usize,
-    height: usize,
+    last_frame: String,
     pages: usize,
     scroll: usize,
 }
@@ -71,7 +71,7 @@ impl<'a> List<'a> {
             filtering: false,
             filterable: false,
             filter: String::new(),
-            height: 0,
+            last_frame: String::new(),
             cur_page: 0,
             pages: 0,
             success_items: 4,
@@ -128,13 +128,14 @@ impl<'a> List<'a> {
         let ctrlc_handle = ctrlc::show_cursor_after_ctrlc(&self.term)?;
 
         loop {
+            self.refresh_layout();
             let term = self.term.clone();
             crate::synchronized_output::run(&term, || {
                 self.clear()?;
                 let output = self.render()?;
                 self.term.write_all(output.as_bytes())?;
                 self.term.flush()?;
-                self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
+                self.last_frame = output;
                 Ok(())
             })?;
             if self.filtering {
@@ -254,6 +255,23 @@ impl<'a> List<'a> {
         }
     }
 
+    fn refresh_layout(&mut self) {
+        self.resize_layout(self.term.size().0 as usize);
+    }
+
+    fn resize_layout(&mut self, rows: usize) {
+        let capacity = rows.max(8) - 5;
+        if capacity == self.capacity {
+            return;
+        }
+        self.capacity = capacity;
+        self.pages = self.get_pages();
+        self.cur_page = self.cur_page.min(self.pages.saturating_sub(1));
+        self.scroll = self
+            .scroll
+            .min(self.filtered_entries().len().saturating_sub(1));
+    }
+
     fn visible_entries(&self) -> Vec<&&'a str> {
         let filtered = self.filtered_entries();
         let start = (self.cur_page * self.capacity) + self.scroll;
@@ -347,12 +365,14 @@ impl<'a> List<'a> {
     }
 
     fn clear(&mut self) -> Result<(), io::Error> {
-        if self.height > 0 {
-            self.term.clear_last_lines(self.height)?;
-        } else {
+        if self.last_frame.is_empty() {
             self.term.clear_line()?;
+        } else {
+            let height =
+                crate::height::rendered_height(&self.last_frame, self.term.size().1 as usize);
+            self.term.clear_last_lines(height)?;
         }
-        self.height = 0;
+        self.last_frame.clear();
         Ok(())
     }
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -127,12 +127,19 @@ impl<'a> List<'a> {
     pub fn run(mut self) -> Result<(), io::Error> {
         let ctrlc_handle = ctrlc::show_cursor_after_ctrlc(&self.term)?;
         let mut events = crate::event::EventReader::new()?;
+        let mut reset_viewport = false;
 
         loop {
             self.refresh_layout();
             let term = self.term.clone();
             crate::synchronized_output::run(&term, || {
-                self.clear()?;
+                if reset_viewport {
+                    self.term.clear_screen()?;
+                    self.last_frame.clear();
+                    reset_viewport = false;
+                } else {
+                    self.clear()?;
+                }
                 let output = self.render()?;
                 self.term.write_all(output.as_bytes())?;
                 self.term.flush()?;
@@ -140,6 +147,7 @@ impl<'a> List<'a> {
                 Ok(())
             })?;
             let Some(key) = events.read_key(&self.term)? else {
+                reset_viewport = true;
                 continue;
             };
             if self.filtering {

--- a/src/list.rs
+++ b/src/list.rs
@@ -264,12 +264,13 @@ impl<'a> List<'a> {
         if capacity == self.capacity {
             return;
         }
+        let entry_count = self.filtered_entries().len();
+        let start =
+            (self.cur_page * self.capacity + self.scroll).min(entry_count.saturating_sub(capacity));
         self.capacity = capacity;
+        self.cur_page = start / self.capacity;
+        self.scroll = start % self.capacity;
         self.pages = self.get_pages();
-        self.cur_page = self.cur_page.min(self.pages.saturating_sub(1));
-        self.scroll = self
-            .scroll
-            .min(self.filtered_entries().len().saturating_sub(1));
     }
 
     fn visible_entries(&self) -> Vec<&&'a str> {
@@ -406,5 +407,35 @@ mod tests {
             },
             without_ansi(list.render().unwrap().as_str())
         )
+    }
+
+    #[test]
+    fn resize_preserves_first_visible_entry() {
+        let items = (0..20).map(|value| value.to_string()).collect::<Vec<_>>();
+        let item_refs = items.iter().map(String::as_str).collect::<Vec<_>>();
+        let mut list = List::new("Items").items(&item_refs);
+        list.capacity = 10;
+        list.cur_page = 1;
+        list.scroll = 2;
+
+        list.resize_layout(9);
+
+        assert_eq!(list.capacity, 4);
+        assert_eq!(*list.visible_entries()[0], "12");
+    }
+
+    #[test]
+    fn resize_clamps_scroll_to_last_full_view() {
+        let items = (0..20).map(|value| value.to_string()).collect::<Vec<_>>();
+        let item_refs = items.iter().map(String::as_str).collect::<Vec<_>>();
+        let mut list = List::new("Items").items(&item_refs);
+        list.capacity = 4;
+        list.cur_page = 4;
+        list.scroll = 2;
+
+        list.resize_layout(20);
+
+        assert_eq!(list.capacity, 15);
+        assert_eq!(*list.visible_entries()[0], "5");
     }
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -139,10 +139,8 @@ impl<'a> List<'a> {
                 self.last_frame = output;
                 Ok(())
             })?;
-            let key = match events.read(&self.term)? {
-                crate::event::Event::Key(key) => key,
-                #[cfg(unix)]
-                crate::event::Event::Resize => continue,
+            let Some(key) = events.read_key(&self.term)? else {
+                continue;
             };
             if self.filtering {
                 match key {

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -67,7 +67,7 @@ pub struct MultiSelect<'a, T> {
     cursor_x: usize,
     cursor_y: usize,
     cursor: usize,
-    height: usize,
+    last_frame: String,
     term: Term,
     pages: usize,
     cur_page: usize,
@@ -90,7 +90,7 @@ impl<'a, T> MultiSelect<'a, T> {
             cursor_y: 0,
             err: None,
             cursor: 0,
-            height: 0,
+            last_frame: String::new(),
             term: Term::stderr(),
             filter: String::new(),
             filtering: false,
@@ -180,6 +180,7 @@ impl<'a, T> MultiSelect<'a, T> {
         self.min = self.min.min(self.max);
 
         loop {
+            self.refresh_layout();
             let term = self.term.clone();
             crate::synchronized_output::run(&term, || self.redraw())?;
 
@@ -442,6 +443,23 @@ impl<'a, T> MultiSelect<'a, T> {
         self.pages = self.get_pages();
     }
 
+    fn refresh_layout(&mut self) {
+        self.resize_layout(self.term.size().0 as usize);
+    }
+
+    fn resize_layout(&mut self, rows: usize) {
+        let capacity = rows.max(8) - 6;
+        if capacity == self.capacity {
+            return;
+        }
+        self.capacity = capacity;
+        self.pages = self.get_pages();
+        self.cur_page = self.cur_page.min(self.pages.saturating_sub(1));
+        self.cursor = self
+            .cursor
+            .min(self.visible_options().len().saturating_sub(1));
+    }
+
     fn get_pages(&self) -> usize {
         if self.filtering || !self.filter.is_empty() {
             ((self.filtered_options().len() as f64) / self.capacity as f64).ceil() as usize
@@ -661,15 +679,16 @@ impl<'a, T> MultiSelect<'a, T> {
     fn redraw(&mut self) -> io::Result<()> {
         self.cleanup()?;
         let output = self.render()?;
-        self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
         self.term.write_all(output.as_bytes())?;
         self.term.flush()?;
+        self.last_frame = output;
         Ok(())
     }
 
     fn cleanup(&mut self) -> io::Result<()> {
-        self.term.clear_last_lines(self.height)?;
-        self.height = 0;
+        let height = crate::height::rendered_height(&self.last_frame, self.term.size().1 as usize);
+        self.term.clear_last_lines(height)?;
+        self.last_frame.clear();
         Ok(())
     }
 }
@@ -885,5 +904,23 @@ mod tests {
             1,
             "prompt drawn more than once:\n{screen}"
         );
+    }
+
+    #[test]
+    fn resize_updates_capacity_and_clamps_navigation() {
+        let mut select = MultiSelect::new("Pick").options(
+            (0..20)
+                .map(|value| DemandOption::new(value.to_string()))
+                .collect(),
+        );
+        select.cur_page = 10;
+        select.cursor = 10;
+
+        select.resize_layout(10);
+
+        assert_eq!(select.capacity, 4);
+        assert_eq!(select.pages, 5);
+        assert_eq!(select.cur_page, 4);
+        assert_eq!(select.cursor, 3);
     }
 }

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -452,12 +452,13 @@ impl<'a, T> MultiSelect<'a, T> {
         if capacity == self.capacity {
             return;
         }
+        let option_count = self.filtered_options().len();
+        let cursor =
+            (self.cur_page * self.capacity + self.cursor).min(option_count.saturating_sub(1));
         self.capacity = capacity;
         self.pages = self.get_pages();
-        self.cur_page = self.cur_page.min(self.pages.saturating_sub(1));
-        self.cursor = self
-            .cursor
-            .min(self.visible_options().len().saturating_sub(1));
+        self.cur_page = cursor / self.capacity;
+        self.cursor = cursor % self.capacity;
     }
 
     fn get_pages(&self) -> usize {
@@ -907,20 +908,23 @@ mod tests {
     }
 
     #[test]
-    fn resize_updates_capacity_and_clamps_navigation() {
+    fn resize_preserves_focused_option() {
         let mut select = MultiSelect::new("Pick").options(
             (0..20)
                 .map(|value| DemandOption::new(value.to_string()))
                 .collect(),
         );
-        select.cur_page = 10;
-        select.cursor = 10;
+        select.capacity = 10;
+        select.pages = 2;
+        select.cur_page = 1;
+        select.cursor = 5;
 
         select.resize_layout(10);
 
         assert_eq!(select.capacity, 4);
         assert_eq!(select.pages, 5);
-        assert_eq!(select.cur_page, 4);
+        assert_eq!(select.cur_page, 3);
         assert_eq!(select.cursor, 3);
+        assert_eq!(select.visible_options()[select.cursor].label, "15");
     }
 }

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -176,6 +176,7 @@ impl<'a, T> MultiSelect<'a, T> {
     pub fn run(mut self) -> io::Result<Vec<T>> {
         let ctrlc_handle = ctrlc::show_cursor_after_ctrlc(&self.term)?;
         let mut events = crate::event::EventReader::new()?;
+        let mut reset_viewport = false;
 
         self.max = self.max.min(self.options.len());
         self.min = self.min.min(self.max);
@@ -183,9 +184,17 @@ impl<'a, T> MultiSelect<'a, T> {
         loop {
             self.refresh_layout();
             let term = self.term.clone();
-            crate::synchronized_output::run(&term, || self.redraw())?;
+            crate::synchronized_output::run(&term, || {
+                if reset_viewport {
+                    self.term.clear_screen()?;
+                    self.last_frame.clear();
+                    reset_viewport = false;
+                }
+                self.redraw()
+            })?;
 
             let Some(key) = events.read_key(&self.term)? else {
+                reset_viewport = true;
                 continue;
             };
             if self.filtering {

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -175,6 +175,7 @@ impl<'a, T> MultiSelect<'a, T> {
     /// an error of type `io::ErrorKind::Interrupted` is returned.
     pub fn run(mut self) -> io::Result<Vec<T>> {
         let ctrlc_handle = ctrlc::show_cursor_after_ctrlc(&self.term)?;
+        let mut events = crate::event::EventReader::new()?;
 
         self.max = self.max.min(self.options.len());
         self.min = self.min.min(self.max);
@@ -184,8 +185,13 @@ impl<'a, T> MultiSelect<'a, T> {
             let term = self.term.clone();
             crate::synchronized_output::run(&term, || self.redraw())?;
 
+            let key = match events.read(&self.term)? {
+                crate::event::Event::Key(key) => key,
+                #[cfg(unix)]
+                crate::event::Event::Resize => continue,
+            };
             if self.filtering {
-                match self.term.read_key()? {
+                match key {
                     Key::ArrowDown => self.handle_down()?,
                     Key::ArrowUp => self.handle_up()?,
                     Key::ArrowLeft => self.handle_left()?,
@@ -204,7 +210,7 @@ impl<'a, T> MultiSelect<'a, T> {
                 }
             } else {
                 self.term.hide_cursor()?;
-                match self.term.read_key()? {
+                match key {
                     Key::ArrowDown | Key::Char('j') => self.handle_down()?,
                     Key::ArrowUp | Key::Char('k') => self.handle_up()?,
                     Key::ArrowLeft | Key::Char('h') => self.handle_left()?,

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -185,10 +185,8 @@ impl<'a, T> MultiSelect<'a, T> {
             let term = self.term.clone();
             crate::synchronized_output::run(&term, || self.redraw())?;
 
-            let key = match events.read(&self.term)? {
-                crate::event::Event::Key(key) => key,
-                #[cfg(unix)]
-                crate::event::Event::Resize => continue,
+            let Some(key) = events.read_key(&self.term)? else {
+                continue;
             };
             if self.filtering {
                 match key {

--- a/src/select.rs
+++ b/src/select.rs
@@ -321,7 +321,7 @@ impl<'a, T> Select<'a, T> {
     }
 
     fn get_pages(&self) -> usize {
-        ((self.options.len() as f64) / self.capacity as f64).ceil() as usize
+        ((self.filtered_options().len() as f64) / self.capacity as f64).ceil() as usize
     }
 
     fn refresh_layout(&mut self) {
@@ -333,12 +333,13 @@ impl<'a, T> Select<'a, T> {
         if capacity == self.capacity {
             return;
         }
+        let option_count = self.filtered_options().len();
+        let cursor =
+            (self.cur_page * self.capacity + self.cursor_y).min(option_count.saturating_sub(1));
         self.capacity = capacity;
         self.pages = self.get_pages();
-        self.cur_page = self.cur_page.min(self.pages.saturating_sub(1));
-        self.cursor_y = self
-            .cursor_y
-            .min(self.visible_options().len().saturating_sub(1));
+        self.cur_page = cursor / self.capacity;
+        self.cursor_y = cursor % self.capacity;
     }
 
     fn get_selected_option_idx(&mut self) -> usize {
@@ -644,20 +645,23 @@ mod tests {
     }
 
     #[test]
-    fn resize_updates_capacity_and_clamps_navigation() {
+    fn resize_preserves_focused_option() {
         let mut select = Select::new("Pick").options(
             (0..20)
                 .map(|value| DemandOption::new(value.to_string()))
                 .collect(),
         );
-        select.cur_page = 10;
-        select.cursor_y = 10;
+        select.capacity = 10;
+        select.pages = 2;
+        select.cur_page = 1;
+        select.cursor_y = 5;
 
         select.resize_layout(10);
 
         assert_eq!(select.capacity, 4);
         assert_eq!(select.pages, 5);
-        assert_eq!(select.cur_page, 4);
+        assert_eq!(select.cur_page, 3);
         assert_eq!(select.cursor_y, 3);
+        assert_eq!(select.visible_options()[select.cursor_y].label, "15");
     }
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -137,12 +137,19 @@ impl<'a, T> Select<'a, T> {
     pub fn run(mut self) -> io::Result<T> {
         let ctrlc_handle = ctrlc::show_cursor_after_ctrlc(&self.term)?;
         let mut events = crate::event::EventReader::new()?;
+        let mut reset_viewport = false;
 
         loop {
             self.refresh_layout();
             let term = self.term.clone();
             crate::synchronized_output::run(&term, || {
-                self.clear()?;
+                if reset_viewport {
+                    self.term.clear_screen()?;
+                    self.last_frame.clear();
+                    reset_viewport = false;
+                } else {
+                    self.clear()?;
+                }
                 self.draw()?;
                 self.term.hide_cursor()
             })?;
@@ -162,6 +169,7 @@ impl<'a, T> Select<'a, T> {
             };
 
             let Some(key) = events.read_key(&self.term)? else {
+                reset_viewport = true;
                 continue;
             };
             if self.filtering {

--- a/src/select.rs
+++ b/src/select.rs
@@ -53,7 +53,7 @@ pub struct Select<'a, T> {
 
     cursor_x: usize,
     cursor_y: usize,
-    height: usize,
+    last_frame: String,
     term: Term,
     filter: String,
     filtering: bool,
@@ -74,7 +74,7 @@ impl<'a, T> Select<'a, T> {
             theme: &theme::DEFAULT,
             cursor_x: 0,
             cursor_y: 0,
-            height: 0,
+            last_frame: String::new(),
             term: Term::stderr(),
             filter: String::new(),
             filtering: false,
@@ -138,6 +138,7 @@ impl<'a, T> Select<'a, T> {
         let ctrlc_handle = ctrlc::show_cursor_after_ctrlc(&self.term)?;
 
         loop {
+            self.refresh_layout();
             let term = self.term.clone();
             crate::synchronized_output::run(&term, || {
                 self.clear()?;
@@ -323,6 +324,23 @@ impl<'a, T> Select<'a, T> {
         ((self.options.len() as f64) / self.capacity as f64).ceil() as usize
     }
 
+    fn refresh_layout(&mut self) {
+        self.resize_layout(self.term.size().0 as usize);
+    }
+
+    fn resize_layout(&mut self, rows: usize) {
+        let capacity = rows.max(8) - 6;
+        if capacity == self.capacity {
+            return;
+        }
+        self.capacity = capacity;
+        self.pages = self.get_pages();
+        self.cur_page = self.cur_page.min(self.pages.saturating_sub(1));
+        self.cursor_y = self
+            .cursor_y
+            .min(self.visible_options().len().saturating_sub(1));
+    }
+
     fn get_selected_option_idx(&mut self) -> usize {
         self.visible_options()
             .iter()
@@ -496,13 +514,14 @@ impl<'a, T> Select<'a, T> {
         let output = self.render()?;
         self.term.write_all(output.as_bytes())?;
         self.term.flush()?;
-        self.height = crate::height::rendered_height(&output, self.term.size().1 as usize);
+        self.last_frame = output;
         Ok(())
     }
 
     fn clear(&mut self) -> io::Result<()> {
-        self.term.clear_last_lines(self.height)?;
-        self.height = 0;
+        let height = crate::height::rendered_height(&self.last_frame, self.term.size().1 as usize);
+        self.term.clear_last_lines(height)?;
+        self.last_frame.clear();
         Ok(())
     }
 }
@@ -622,5 +641,23 @@ mod tests {
             1,
             "prompt drawn more than once:\n{screen}"
         );
+    }
+
+    #[test]
+    fn resize_updates_capacity_and_clamps_navigation() {
+        let mut select = Select::new("Pick").options(
+            (0..20)
+                .map(|value| DemandOption::new(value.to_string()))
+                .collect(),
+        );
+        select.cur_page = 10;
+        select.cursor_y = 10;
+
+        select.resize_layout(10);
+
+        assert_eq!(select.capacity, 4);
+        assert_eq!(select.pages, 5);
+        assert_eq!(select.cur_page, 4);
+        assert_eq!(select.cursor_y, 3);
     }
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -136,6 +136,7 @@ impl<'a, T> Select<'a, T> {
     /// an error of type `io::ErrorKind::Interrupted` is returned.
     pub fn run(mut self) -> io::Result<T> {
         let ctrlc_handle = ctrlc::show_cursor_after_ctrlc(&self.term)?;
+        let mut events = crate::event::EventReader::new()?;
 
         loop {
             self.refresh_layout();
@@ -160,8 +161,13 @@ impl<'a, T> Select<'a, T> {
                 Ok::<T, io::Error>(selected.item)
             };
 
+            let key = match events.read(&self.term)? {
+                crate::event::Event::Key(key) => key,
+                #[cfg(unix)]
+                crate::event::Event::Resize => continue,
+            };
             if self.filtering {
-                match self.term.read_key()? {
+                match key {
                     Key::ArrowDown => self.handle_down()?,
                     Key::ArrowUp => self.handle_up()?,
                     Key::ArrowLeft => self.handle_left()?,
@@ -175,7 +181,7 @@ impl<'a, T> Select<'a, T> {
                     _ => {}
                 }
             } else {
-                match self.term.read_key()? {
+                match key {
                     Key::ArrowDown | Key::Char('j') => self.handle_down()?,
                     Key::ArrowUp | Key::Char('k') => self.handle_up()?,
                     Key::ArrowLeft | Key::Char('h') => self.handle_left()?,

--- a/src/select.rs
+++ b/src/select.rs
@@ -161,10 +161,8 @@ impl<'a, T> Select<'a, T> {
                 Ok::<T, io::Error>(selected.item)
             };
 
-            let key = match events.read(&self.term)? {
-                crate::event::Event::Key(key) => key,
-                #[cfg(unix)]
-                crate::event::Event::Resize => continue,
+            let Some(key) = events.read_key(&self.term)? else {
+                continue;
             };
             if self.filtering {
                 match key {

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
 const BEGIN: &[u8] = b"\x1b[?2026h";
+const CLEAR_SCREEN: &[u8] = b"\r\x1b[2J\r\x1b[H";
 
 #[test]
 fn resize_child_scenario() {
@@ -81,10 +82,18 @@ fn resize_redraws_without_keyboard_input() {
     child.wait().expect("wait child");
     drop(pair.master);
     reader_thread.join().expect("join reader");
+    while let Ok(chunk) = rx.try_recv() {
+        output.extend(chunk);
+    }
 
     assert!(
         redrew,
         "prompt did not redraw after SIGWINCH without keyboard input: {}",
+        String::from_utf8_lossy(&output).escape_debug()
+    );
+    assert!(
+        frame(&output, 1).is_some_and(|redraw| occurrences(redraw, CLEAR_SCREEN) == 1),
+        "resize redraw did not reset the viewport: {}",
         String::from_utf8_lossy(&output).escape_debug()
     );
 }
@@ -108,4 +117,14 @@ fn occurrences(haystack: &[u8], needle: &[u8]) -> usize {
         .windows(needle.len())
         .filter(|window| *window == needle)
         .count()
+}
+
+fn frame(output: &[u8], index: usize) -> Option<&[u8]> {
+    let start = output
+        .windows(BEGIN.len())
+        .enumerate()
+        .filter(|(_, window)| *window == BEGIN)
+        .nth(index)
+        .map(|(offset, _)| offset + BEGIN.len())?;
+    Some(&output[start..])
 }

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -1,0 +1,111 @@
+//! Verifies that a terminal resize redraws an idle prompt without requiring
+//! keyboard input.
+#![cfg(unix)]
+
+use std::io::{Read, Write};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+
+const BEGIN: &[u8] = b"\x1b[?2026h";
+
+#[test]
+fn resize_child_scenario() {
+    if std::env::var_os("DEMAND_RESIZE_PTY_SCENARIO").is_none() {
+        return;
+    }
+
+    use demand::{DemandOption, Select};
+
+    Select::new("Choose")
+        .option(DemandOption::new("one"))
+        .option(DemandOption::new("two"))
+        .run()
+        .expect("run select");
+
+    std::process::exit(0);
+}
+
+#[test]
+fn resize_redraws_without_keyboard_input() {
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("openpty");
+
+    let mut cmd = CommandBuilder::new(std::env::current_exe().expect("current_exe"));
+    cmd.args(["--exact", "resize_child_scenario", "--nocapture"]);
+    cmd.env("DEMAND_RESIZE_PTY_SCENARIO", "1");
+
+    let mut child = pair.slave.spawn_command(cmd).expect("spawn child");
+    drop(pair.slave);
+
+    let mut writer = pair.master.take_writer().expect("take writer");
+    let mut reader = pair.master.try_clone_reader().expect("clone reader");
+    let (tx, rx) = mpsc::channel();
+    let reader_thread = thread::spawn(move || {
+        let mut chunk = [0; 4096];
+        while let Ok(count) = reader.read(&mut chunk) {
+            if count == 0 || tx.send(chunk[..count].to_vec()).is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut output = Vec::new();
+    assert!(
+        wait_for_frames(&rx, &mut output, 1),
+        "prompt did not render its initial frame"
+    );
+
+    pair.master
+        .resize(PtySize {
+            rows: 10,
+            cols: 40,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("resize pty");
+
+    let redrew = wait_for_frames(&rx, &mut output, 2);
+
+    writer.write_all(b"\r").expect("submit prompt");
+    writer.flush().expect("flush input");
+    drop(writer);
+    child.wait().expect("wait child");
+    drop(pair.master);
+    reader_thread.join().expect("join reader");
+
+    assert!(
+        redrew,
+        "prompt did not redraw after SIGWINCH without keyboard input: {}",
+        String::from_utf8_lossy(&output).escape_debug()
+    );
+}
+
+fn wait_for_frames(rx: &Receiver<Vec<u8>>, output: &mut Vec<u8>, expected: usize) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while occurrences(output, BEGIN) < expected {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return false;
+        };
+        match rx.recv_timeout(remaining) {
+            Ok(chunk) => output.extend(chunk),
+            Err(_) => return false,
+        }
+    }
+    true
+}
+
+fn occurrences(haystack: &[u8], needle: &[u8]) -> usize {
+    haystack
+        .windows(needle.len())
+        .filter(|window| *window == needle)
+        .count()
+}


### PR DESCRIPTION
## Summary

- retain each selector's previous rendered frame instead of only its original physical height
- recalculate that frame's wrapped height using the terminal's current width before clearing it
- refresh page capacity from the current terminal height on every redraw
- clamp pages, cursors, and list scroll positions when the resized viewport no longer contains them
- add focused capacity and navigation-clamping tests for `Select` and `MultiSelect`

## Root cause

The wrapped-row fix in #192 recorded how many physical rows a frame occupied when it was drawn. After a terminal resize, that number could become stale because the terminal reflows the same text at a different width. Selector capacity was also calculated only at construction, so pagination continued using the original terminal height.

## Behavior

`Select`, `MultiSelect`, and `List` now retain the previous frame text. On the next redraw after a resize, they measure that old frame at the new width, erase the reflowed footprint, recalculate capacity from the new height, clamp navigation state, and render the corrected layout.

This intentionally updates on the next input/redraw. Immediate idle redraw would require a resize-aware input event API; `console::Term::read_key` currently blocks on key input and does not expose resize events.

The branch is rebased onto the merged #193, so resize correction is enclosed in the synchronized-output update: geometry is recalculated correctly and the clear/redraw transition is presented atomically.

## Validation

- `cargo fmt --check`
- `cargo test --lib --tests` (45 unit tests and 16 integration tests passed)
- `cargo clippy --all-targets -- -D warnings`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Unix-only low-level TTY/signal/`select` code affects all three interactive prompts; non-Unix still uses blocking `read_key` only, but incorrect raw-mode or signal handling could break input or leave the terminal in a bad state.
> 
> **Overview**
> **Terminal resize handling** for `Select`, `MultiSelect`, and `List` on Unix: prompts now react when the window changes size, not only on the next keypress.
> 
> Adds **`EventReader`** (`src/event.rs`) that multiplexes keyboard input with **SIGWINCH** via `select`, raw TTY mode, and a signal-hook pipe. Resize events surface as `read_key` returning `None`, which triggers a full-screen clear and redraw on the next loop.
> 
> **Layout and erase fixes:** widgets keep the **previous frame text** (`last_frame`) instead of a fixed row count. Before clearing, wrapped height is recomputed at the **current** terminal width; each redraw calls **`refresh_layout`** to derive page capacity from terminal height and **clamp** page, cursor, and list scroll so the focused / first-visible item stays stable. `Select` paging now counts **filtered** options.
> 
> **Tests:** unit tests for `resize_layout`, plus a **PTY** integration test (`tests/resize.rs`) asserting an idle prompt emits a second synchronized frame after resize without keyboard input. **`libc`** (unix) and **`portable-pty`** (dev) dependencies added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f712cafe044a4112be6a0413d47c7a5539b18fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->