### PR TITLE
chore(ci): add cargo semver checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,18 +21,25 @@ jobs:
       - run: cargo test --lib --tests
       - run: hk check --all
 
+  semver:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
+
   test-ci:
     runs-on: ubuntu-latest
     timeout-minutes: 1
-    needs: [test]
+    needs: [test, semver]
     # Run on success or upstream failure but skip when the workflow is cancelled
     # — `always()` would override `cancel-in-progress` and waste a runner.
     if: ${{ !cancelled() }}
     steps:
       - name: Check CI job results
         run: |
-          if [ "${{ needs.test.result }}" != "success" ]; then
-            echo "test failed or was skipped"
+          if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.semver.result }}" != "success" ]; then
+            echo "test or semver failed or was skipped"
             exit 1
           fi
           echo "All CI jobs completed successfully"


### PR DESCRIPTION
## Summary

- add a dedicated cargo-semver-checks job to CI
- compare the current public API against the latest non-yanked demand release on crates.io
- include the semver job in the existing aggregate `test-ci` status check
- pin cargo-semver-checks-action to the v2.9 commit

## Why

Unit tests and clippy do not detect accidental breaking changes to the crate's public API. This makes SemVer compatibility an explicit merge gate.

## Validation

- cargo-semver-checks 0.49.0: 223 checks passed against demand 2.0.4
- actionlint

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no runtime or application code; risk is limited to CI possibly blocking merges on semver violations.
> 
> **Overview**
> Adds a **`semver`** CI job that runs **`cargo-semver-checks-action`** (pinned to v2.9) on Ubuntu to gate merges on public API SemVer compatibility against the latest published crate release.
> 
> The aggregate **`test-ci`** job now **`needs`** both **`test`** and **`semver`**, and fails if either job did not succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 720a0961c14da7a6428a58a3817518b0a08f7905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->