### PR TITLE
feat: use Ctrl-N/Ctrl-P for vertical movement in lists

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -7,6 +7,7 @@ use console::{Key, Term, measure_text_width};
 use termcolor::{Buffer, WriteColor};
 
 use crate::ctrlc;
+use crate::keys::{CTRL_U, CTRL_W};
 use crate::{Theme, theme};
 
 /// Trait for implementing autocompletion features for text inputs.
@@ -199,9 +200,6 @@ pub struct Input<'a> {
     input_line_offset: usize,
     suggestions_scroll_offset: usize,
 }
-
-const CTRL_U: char = '\u{15}';
-const CTRL_W: char = '\u{17}';
 
 impl<'a> Input<'a> {
     /// Creates a new input with the given title.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,0 +1,3 @@
+// Ctrl-N/Ctrl-P are the readline/emacs bindings for next/previous line
+pub(crate) const CTRL_N: char = '\u{e}';
+pub(crate) const CTRL_P: char = '\u{10}';

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,3 +1,6 @@
 // Ctrl-N/Ctrl-P are the readline/emacs bindings for next/previous line
 pub(crate) const CTRL_N: char = '\u{e}';
 pub(crate) const CTRL_P: char = '\u{10}';
+
+pub(crate) const CTRL_U: char = '\u{15}';
+pub(crate) const CTRL_W: char = '\u{17}';

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ mod dialog;
 mod event;
 mod height;
 mod input;
+mod keys;
 mod list;
 mod multiselect;
 mod option;

--- a/src/list.rs
+++ b/src/list.rs
@@ -4,6 +4,7 @@ use console::{Key, Term};
 use std::io::Write;
 use termcolor::{Buffer, WriteColor};
 
+use crate::keys::{CTRL_N, CTRL_P};
 use crate::{Theme, ctrlc, theme};
 
 /// Display a list of options
@@ -161,8 +162,8 @@ impl<'a> List<'a> {
             } else {
                 self.term.hide_cursor()?;
                 match key {
-                    Key::ArrowUp | Key::Char('k') => self.handle_up(),
-                    Key::ArrowDown | Key::Char('j') => self.handle_down()?,
+                    Key::ArrowDown | Key::Char('j') | Key::Char(CTRL_N) => self.handle_down()?,
+                    Key::ArrowUp | Key::Char('k') | Key::Char(CTRL_P) => self.handle_up(),
                     Key::ArrowLeft | Key::Char('h') => self.handle_left()?,
                     Key::ArrowRight | Key::Char('l') => self.handle_right()?,
                     Key::Char('/') if self.filterable => self.handle_start_filtering(),

--- a/src/list.rs
+++ b/src/list.rs
@@ -153,10 +153,12 @@ impl<'a> List<'a> {
             };
             if self.filtering {
                 match key {
+                    Key::ArrowDown | Key::Char(CTRL_N) => self.handle_down()?,
+                    Key::ArrowUp | Key::Char(CTRL_P) => self.handle_up(),
                     Key::Enter => self.handle_stop_filtering(true)?,
                     Key::Escape => self.handle_stop_filtering(false)?,
                     Key::Backspace => self.handle_filter_backspace()?,
-                    Key::Char(c) => self.handle_filter_key(c)?,
+                    Key::Char(c) if !c.is_control() => self.handle_filter_key(c)?,
                     _ => {}
                 }
             } else {

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -200,8 +200,8 @@ impl<'a, T> MultiSelect<'a, T> {
             };
             if self.filtering {
                 match key {
-                    Key::ArrowDown => self.handle_down()?,
-                    Key::ArrowUp => self.handle_up()?,
+                    Key::ArrowDown | Key::Char(CTRL_N) => self.handle_down()?,
+                    Key::ArrowUp | Key::Char(CTRL_P) => self.handle_up()?,
                     Key::ArrowLeft => self.handle_left()?,
                     Key::ArrowRight => self.handle_right()?,
                     Key::Enter => {
@@ -213,7 +213,7 @@ impl<'a, T> MultiSelect<'a, T> {
                     Key::Escape => self.handle_stop_filtering(false)?,
                     Key::Backspace => self.handle_filter_backspace()?,
                     key if key == self.toggle_key => self.handle_toggle(),
-                    Key::Char(c) => self.handle_filter_key(c)?,
+                    Key::Char(c) if !c.is_control() => self.handle_filter_key(c)?,
                     _ => {}
                 }
             } else {

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -8,6 +8,7 @@ use fuzzy_matcher::skim::SkimMatcherV2;
 use itertools::Itertools;
 use termcolor::{Buffer, WriteColor};
 
+use crate::keys::{CTRL_N, CTRL_P};
 use crate::theme::Theme;
 use crate::{DemandOption, ctrlc, theme};
 
@@ -218,8 +219,8 @@ impl<'a, T> MultiSelect<'a, T> {
             } else {
                 self.term.hide_cursor()?;
                 match key {
-                    Key::ArrowDown | Key::Char('j') => self.handle_down()?,
-                    Key::ArrowUp | Key::Char('k') => self.handle_up()?,
+                    Key::ArrowDown | Key::Char('j') | Key::Char(CTRL_N) => self.handle_down()?,
+                    Key::ArrowUp | Key::Char('k') | Key::Char(CTRL_P) => self.handle_up()?,
                     Key::ArrowLeft | Key::Char('h') => self.handle_left()?,
                     Key::ArrowRight | Key::Char('l') => self.handle_right()?,
                     key if key == self.toggle_key || key == Key::Char('x') => self.handle_toggle(),

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::io::Write;
 
+use crate::keys::{CTRL_N, CTRL_P};
 use crate::theme::Theme;
 use crate::{DemandOption, ctrlc, theme};
 use console::{Alignment, Key, Term};
@@ -188,8 +189,8 @@ impl<'a, T> Select<'a, T> {
                 }
             } else {
                 match key {
-                    Key::ArrowDown | Key::Char('j') => self.handle_down()?,
-                    Key::ArrowUp | Key::Char('k') => self.handle_up()?,
+                    Key::ArrowDown | Key::Char('j') | Key::Char(CTRL_N) => self.handle_down()?,
+                    Key::ArrowUp | Key::Char('k') | Key::Char(CTRL_P) => self.handle_up()?,
                     Key::ArrowLeft | Key::Char('h') => self.handle_left()?,
                     Key::ArrowRight | Key::Char('l') => self.handle_right()?,
                     Key::Char('/') if self.filterable => self.handle_start_filtering(),

--- a/src/select.rs
+++ b/src/select.rs
@@ -175,8 +175,8 @@ impl<'a, T> Select<'a, T> {
             };
             if self.filtering {
                 match key {
-                    Key::ArrowDown => self.handle_down()?,
-                    Key::ArrowUp => self.handle_up()?,
+                    Key::ArrowDown | Key::Char(CTRL_N) => self.handle_down()?,
+                    Key::ArrowUp | Key::Char(CTRL_P) => self.handle_up()?,
                     Key::ArrowLeft => self.handle_left()?,
                     Key::ArrowRight => self.handle_right()?,
                     Key::Enter if !self.visible_options().is_empty() => {
@@ -184,7 +184,7 @@ impl<'a, T> Select<'a, T> {
                     }
                     Key::Escape => self.handle_stop_filtering(false)?,
                     Key::Backspace => self.handle_filter_backspace()?,
-                    Key::Char(c) => self.handle_filter_key(c)?,
+                    Key::Char(c) if !c.is_control() => self.handle_filter_key(c)?,
                     _ => {}
                 }
             } else {


### PR DESCRIPTION
A small change that allows CTRL N/CTRL P to move vertically in lists.

I especially want this feature in `mise run` as I use these keybinds to move in most lists 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ctrl-N and Ctrl-P keyboard shortcuts for moving up and down in lists, multi-select menus, and selection prompts.
  * Added Ctrl-U and Ctrl-W control-key support for input editing.
* **Bug Fixes**
  * Control characters entered while filtering are no longer treated as filter text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->