### PR TITLE
fix: reset cursor_x when clearing filter on Escape

### DIFF
--- a/src/select.rs
+++ b/src/select.rs
@@ -282,6 +282,7 @@ impl<'a, T> Select<'a, T> {
         self.cur_page = 0;
 
         if !save {
+            self.cursor_x = 0;
             self.filter.clear();
             self.pages = self.get_pages();
         }


### PR DESCRIPTION
## Problem

In `Select`, pressing Escape (`handle_stop_filtering(false)`) clears the filter string but does not reset `cursor_x` to 0. On the next filtering session, `handle_filter_backspace` calls `self.get_char_idx(&self.filter, self.cursor_x - 1)` with a stale `cursor_x`, which returns an index past the end of the (now shorter) filter string, making `self.filter.remove(idx)` panic:

```
Message:  cannot remove a char from the end of a string
Location: demand-2.0.4/src/select.rs:305
```

Observed downstream in [mise](https://github.com/jdx/mise) (`mise run` task picker): type a filter, press Escape, start filtering again, press Backspace → crash.

## Fix

Reset `cursor_x = 0` alongside `filter.clear()` when the filter is not saved, so the cursor state stays consistent with the empty filter string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed selector state not fully resetting when filtering is canceled, ensuring the horizontal cursor returns to its initial position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->