### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2.1.0](https://github.com/jdx/demand/compare/v2.0.5...v2.1.0) - 2026-08-25
+
+### Added
+
+- add project logo ([#201](https://github.com/jdx/demand/pull/201))
+
+### Fixed
+
+- match space-separated filter terms ([#209](https://github.com/jdx/demand/pull/209))
+- reset cursor_x when clearing filter on Escape ([#199](https://github.com/jdx/demand/pull/199))
+
+### Other
+
+- *(deps)* update dependency hk to v1.56.1 ([#208](https://github.com/jdx/demand/pull/208))
+- *(deps)* update dtolnay/rust-toolchain digest to 4360b52 ([#206](https://github.com/jdx/demand/pull/206))
+- *(deps)* update swatinem/rust-cache digest to 6323deb ([#207](https://github.com/jdx/demand/pull/207))
+- *(deps)* update dependency hk to v1.55.0 ([#205](https://github.com/jdx/demand/pull/205))
+- *(deps)* update dependency hk to v1.54.1 ([#204](https://github.com/jdx/demand/pull/204))
+- *(deps)* update jdx/mise-action digest to 7e36c90 ([#203](https://github.com/jdx/demand/pull/203))
+- *(deps)* update dependency hk to v1.54.0 ([#202](https://github.com/jdx/demand/pull/202))
+- Migrate test terminal emulator from vt100 to rio-vt ([#198](https://github.com/jdx/demand/pull/198))
+
 ## [2.0.5](https://github.com/jdx/demand/compare/v2.0.4...v2.0.5) - 2026-07-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.1.0](https://github.com/jdx/demand/compare/v2.0.5...v2.1.0) - 2026-08-04
+
+### Added
+
+- add project logo ([#201](https://github.com/jdx/demand/pull/201))
+
+### Fixed
+
+- reset cursor_x when clearing filter on Escape ([#199](https://github.com/jdx/demand/pull/199))
+
+### Other
+
+- *(deps)* update dependency hk to v1.54.0 ([#202](https://github.com/jdx/demand/pull/202))
+- Migrate test terminal emulator from vt100 to rio-vt ([#198](https://github.com/jdx/demand/pull/198))
+
 ## [2.0.5](https://github.com/jdx/demand/compare/v2.0.4...v2.0.5) - 2026-07-26
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "demand"
-version = "2.0.5"
+version = "2.1.0"
 edition = "2024"
 description = "A CLI prompt library"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `demand`: 2.0.5 -> 2.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.0](https://github.com/jdx/demand/compare/v2.0.5...v2.1.0) - 2026-08-25

### Added

- add project logo ([#201](https://github.com/jdx/demand/pull/201))

### Fixed

- match space-separated filter terms ([#209](https://github.com/jdx/demand/pull/209))
- reset cursor_x when clearing filter on Escape ([#199](https://github.com/jdx/demand/pull/199))

### Other

- *(deps)* update dependency hk to v1.56.1 ([#208](https://github.com/jdx/demand/pull/208))
- *(deps)* update dtolnay/rust-toolchain digest to 4360b52 ([#206](https://github.com/jdx/demand/pull/206))
- *(deps)* update swatinem/rust-cache digest to 6323deb ([#207](https://github.com/jdx/demand/pull/207))
- *(deps)* update dependency hk to v1.55.0 ([#205](https://github.com/jdx/demand/pull/205))
- *(deps)* update dependency hk to v1.54.1 ([#204](https://github.com/jdx/demand/pull/204))
- *(deps)* update jdx/mise-action digest to 7e36c90 ([#203](https://github.com/jdx/demand/pull/203))
- *(deps)* update dependency hk to v1.54.0 ([#202](https://github.com/jdx/demand/pull/202))
- Migrate test terminal emulator from vt100 to rio-vt ([#198](https://github.com/jdx/demand/pull/198))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and changelog-only release; no runtime code changes in this PR.
> 
> **Overview**
> **Release v2.1.0** bumps the crate from `2.0.5` to `2.1.0` and adds the corresponding **CHANGELOG** entry (2026-08-25).
> 
> The documented user-facing changes shipped in this release (from prior PRs, not in this diff) include **filter matching for space-separated terms**, **resetting `cursor_x` when clearing the filter on Escape**, and a **project logo**; CI/tooling updates include migrating tests from **vt100** to **rio-vt** and routine dependency bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c82485a9c7a23ca7e4b495fc51f1baf02cee74c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->