### PR TITLE
feat: add project logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="./assets/logo.svg" alt="demand logo" width="128" height="128">
+</p>
+
 # demand
 
 [![Crates.io](https://img.shields.io/crates/v/demand)

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,13 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">demand logo</title>
+  <desc id="desc">A terminal prompt chevron followed by a block cursor.</desc>
+  <defs>
+    <linearGradient id="chevron" x1="130" y1="130" x2="294" y2="382" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7571f9"/>
+      <stop offset="1" stop-color="#f780e2"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="#14121c"/>
+  <path d="M152 152 L272 256 L152 360" stroke="url(#chevron)" stroke-width="44" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="306" y="196" width="76" height="120" rx="14" fill="#02bf87"/>
+</svg>


### PR DESCRIPTION
demand had no logo. This adds one, built from the library's own visual language rather than something generic: the `❯` prompt chevron (demand's `cursor_str`) in the Charm theme's indigo → fuchsia range, followed by a green block input cursor, on a dark terminal tile.

All three colors are lifted straight from `Theme::charm()` in `src/theme.rs` — indigo `#7571f9`, fuchsia `#f780e2`, green `#02bf87`.

- `assets/logo.svg` — 512×512, `rx=112`
- `README.md` — centered above the `# demand` heading at 128px

It reads cleanly down to 32px, which is the size jdx.dev renders project logos at.

The companion change adding it to jdx.dev is jdx/blog#82.

Note: I had no SVG rasterizer available in this environment, so the file hasn't been checked through a renderer other than the one used to preview the paths — worth a glance at the rendered README before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static asset only; no application logic, APIs, or dependencies change.
> 
> **Overview**
> Adds **branding assets** for demand: a new `assets/logo.svg` (512×512, rounded dark tile) showing a gradient chevron and green block cursor using **Charm theme** colors from `Theme::charm()` (indigo → fuchsia, green `#02bf87`).
> 
> The **README** now shows that logo centered above the `# demand` heading at 128×128. No library or runtime code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa2be80bbacf4a1b3c45af10553ca06eb73ab729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a centered project logo to the top of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->