### PR TITLE
fix: match space-separated filter terms

### DIFF
--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,0 +1,58 @@
+use fuzzy_matcher::FuzzyMatcher;
+use fuzzy_matcher::skim::SkimMatcherV2;
+
+pub(crate) fn score(matcher: &SkimMatcherV2, haystack: &str, query: &str) -> Option<i64> {
+    let haystack = haystack.to_lowercase();
+    query
+        .to_lowercase()
+        .split_whitespace()
+        .try_fold(0_i64, |score, term| {
+            matcher
+                .fuzzy_match(&haystack, term)
+                .map(|term_score| score.saturating_add(term_score))
+        })
+}
+
+pub(crate) fn indices(matcher: &SkimMatcherV2, haystack: &str, query: &str) -> Option<Vec<usize>> {
+    let haystack = haystack.to_lowercase();
+    let mut indices = Vec::new();
+    for term in query.to_lowercase().split_whitespace() {
+        let (_, term_indices) = matcher.fuzzy_indices(&haystack, term)?;
+        indices.extend(term_indices);
+    }
+    indices.sort_unstable();
+    indices.dedup();
+    Some(indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn space_separated_terms_are_anded() {
+        let matcher = SkimMatcherV2::default();
+
+        assert!(score(&matcher, "node:@acme/api#test", "api test").is_some());
+        assert!(score(&matcher, "node:@acme/api#test", "test api").is_some());
+        assert!(score(&matcher, "node:@acme/api#lint", "api test").is_none());
+    }
+
+    #[test]
+    fn repeated_whitespace_is_ignored() {
+        let matcher = SkimMatcherV2::default();
+
+        assert!(score(&matcher, "node:@acme/api#test", " api  test ").is_some());
+        assert_eq!(score(&matcher, "anything", "  \t "), Some(0));
+    }
+
+    #[test]
+    fn indices_include_matches_from_every_term() {
+        let matcher = SkimMatcherV2::default();
+
+        assert_eq!(
+            indices(&matcher, "node:@acme/api#test", "api test"),
+            Some(vec![11, 12, 13, 15, 16, 17, 18])
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod confirm;
 mod ctrlc;
 mod dialog;
 mod event;
+mod fuzzy;
 mod height;
 mod input;
 mod list;

--- a/src/multiselect.rs
+++ b/src/multiselect.rs
@@ -3,7 +3,6 @@ use std::io;
 use std::io::Write;
 
 use console::{Alignment, Key, Term};
-use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use itertools::Itertools;
 use termcolor::{Buffer, WriteColor};
@@ -273,8 +272,7 @@ impl<'a, T> MultiSelect<'a, T> {
                 if self.filter.is_empty() {
                     Some((0, opt))
                 } else {
-                    self.fuzzy_matcher
-                        .fuzzy_match(&opt.label.to_lowercase(), &self.filter.to_lowercase())
+                    crate::fuzzy::score(&self.fuzzy_matcher, &opt.label, &self.filter)
                         .map(|score| (score, opt))
                 }
             })
@@ -656,10 +654,7 @@ impl<'a, T> MultiSelect<'a, T> {
         out: &mut dyn WriteColor,
         label: &str,
     ) -> Result<(), std::io::Error> {
-        let matches = self
-            .fuzzy_matcher
-            .fuzzy_indices(&label.to_lowercase(), &self.filter.to_lowercase());
-        if let Some((_, indices)) = matches {
+        if let Some(indices) = crate::fuzzy::indices(&self.fuzzy_matcher, label, &self.filter) {
             for (j, c) in label.chars().enumerate() {
                 if indices.contains(&j) {
                     out.set_color(&self.theme.selected_option)?;

--- a/src/select.rs
+++ b/src/select.rs
@@ -4,7 +4,6 @@ use std::io::Write;
 use crate::theme::Theme;
 use crate::{DemandOption, ctrlc, theme};
 use console::{Alignment, Key, Term};
-use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use itertools::Itertools;
 use termcolor::{Buffer, WriteColor};
@@ -222,8 +221,7 @@ impl<'a, T> Select<'a, T> {
                 if self.filter.is_empty() {
                     Some((0, opt))
                 } else {
-                    self.fuzzy_matcher
-                        .fuzzy_match(&opt.label.to_lowercase(), &self.filter.to_lowercase())
+                    crate::fuzzy::score(&self.fuzzy_matcher, &opt.label, &self.filter)
                         .map(|score| (score, opt))
                 }
             })
@@ -491,10 +489,7 @@ impl<'a, T> Select<'a, T> {
         out: &mut dyn WriteColor,
         label: &str,
     ) -> Result<(), std::io::Error> {
-        let matches = self
-            .fuzzy_matcher
-            .fuzzy_indices(&label.to_lowercase(), &self.filter.to_lowercase());
-        if let Some((_, indices)) = matches {
+        if let Some(indices) = crate::fuzzy::indices(&self.fuzzy_matcher, label, &self.filter) {
             for (j, c) in label.chars().enumerate() {
                 if indices.contains(&j) {
                     out.set_color(&self.theme.selected_option)?;
@@ -615,6 +610,18 @@ mod tests {
             },
             without_ansi(select.render().unwrap().as_str())
         );
+    }
+
+    #[test]
+    fn filter_matches_space_separated_terms() {
+        let mut select = Select::new("Tasks")
+            .option(DemandOption::new("node:@acme/api#test"))
+            .option(DemandOption::new("node:@acme/api#lint"));
+        select.filter = "api test".to_string();
+
+        let matches = select.filtered_options();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].label, "node:@acme/api#test");
     }
 
     /// Regression for the wrapped-line redraw bug (jdx/aube#1107): an


### PR DESCRIPTION
## Summary

- treat whitespace-separated fuzzy filter terms as an AND query
- combine term scores when ranking matches
- highlight the matched characters from every term
- apply the same behavior to `Select` and `MultiSelect`

This supports queries such as `api test` matching `node:@acme/api#test`, regardless of term order. Repeated and leading/trailing whitespace is ignored.

Motivated by [jdx/mise discussion #12417](https://github.com/jdx/mise/discussions/12417).

## Testing

- `cargo fmt --check`
- `cargo test --lib --tests`
- `cargo clippy --all-targets --all-features -- -D warnings`

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to interactive list filtering and highlighting in Select/MultiSelect, with tests and no auth or data-path impact.
> 
> **Overview**
> **Filter queries with spaces now require every word to match**, instead of treating the whole string as one fuzzy pattern. That enables searches like `api test` to narrow to `node:@acme/api#test` in either term order.
> 
> Shared logic lives in a new **`fuzzy`** module: **`score`** sums per-term Skim scores (options fail the filter if any term misses), and **`indices`** merges match positions for highlight rendering. **`Select`** and **`MultiSelect`** call these helpers for ranking and highlighting; repeated or surrounding whitespace on terms is ignored.
> 
> Unit tests cover AND semantics, whitespace, combined indices, and **`Select::filtered_options`** for the task-label case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa79aa8a1d9f8945e0d9ced66f4fa254a1ef4580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved fuzzy search to support multiple space-separated terms.
  * Search results now require all query terms to match and remain consistently ordered.
  * Matching text is highlighted more accurately across combined terms.

* **Bug Fixes**
  * Removed duplicate match indices and improved handling of repeated spaces and empty queries.

* **Tests**
  * Added coverage for multi-term filtering, term ordering, whitespace, empty searches, and combined matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->