### PR TITLE
docs: add sponsor logos to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,24 @@ A prompt library for Rust. Based on [huh? for Go](https://github.com/charmbracel
 
 ## Sponsors
 
-demand is sponsored by [entire.io](https://entire.io) and [Omacom Foundation](https://omarchy.org/patrons/).
-
-[View all sponsors](https://jdx.dev/sponsors.html).
+<p align="center">
+  Sponsored by<br><br>
+  <a href="https://entire.io">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/entire-lockup.svg">
+      <img src="https://jdx.dev/sponsors/entire-lockup-on-light.svg" alt="Entire" height="36">
+    </picture>
+  </a>
+  &nbsp;&nbsp;&nbsp;
+  <a href="https://omarchy.org/patrons/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://jdx.dev/sponsors/omacom-foundation.svg">
+      <img src="https://jdx.dev/sponsors/omacom-foundation-on-light.svg" alt="Omacom Foundation" height="36">
+    </picture>
+  </a>
+  <br><br>
+  <a href="https://jdx.dev/sponsors.html">View all sponsors</a>
+</p>
 
 ## Input
 


### PR DESCRIPTION
## Summary
- replace the text-only sponsor line with linked Entire and Omarchy wordmarks
- select dark- or light-background assets based on the reader theme
- retain the link to the complete sponsor list

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation with external image URLs; no runtime or library behavior changes.
> 
> **Overview**
> The **Sponsors** section in `README.md` no longer uses a plain text line naming Entire and Omacom Foundation. It now shows **centered, linked wordmarks** for both sponsors, using `<picture>` so **dark vs light** GitHub themes pick the right SVG assets from `jdx.dev`.
> 
> The **View all sponsors** link to `jdx.dev/sponsors.html` is unchanged; only presentation of the primary sponsors was upgraded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f67e1bf1f3253086392e55874475fcacfc0418fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Sponsors section with centered branding for Entire and the Omacom Foundation.
  * Added light and dark logo variants for improved theme support.
  * Added a “View all sponsors” link and removed the previous sponsorship text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->